### PR TITLE
Refactoring Update + Other Adjustments

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
     <body class="dark">
         <div class="header">
             <div class="wrapper">
-                <span class="header-logo"><a href="http://nimbasacitypost.com"><img src="image_res/Logo Nimbasa City Post White Text PNG.png" alt="Nimbasa City Post" style="height: 45px;padding-top: 5px;" /></a></span><span class="nav"><a href="http://nimbasacitypost.com">Home</a> | <a href="http://play.pokemonshowdown.com/vgc">Showdown</a> | <a href="https://www.porydex.com/stats">Showdown Usage Stats</a> | <a href="https://docs.google.com/spreadsheets/d/1axlwmzPA49rYkqXh7zHvAtSP-TKbM0ijGYBPRflLSWw">VGCPastes Repository</a> | <a href="https://github.com/nerd-of-now/VGC-Damage-Calculator">GitHub Page</a> | <a href="https://www.nimbasacitypost.com/2019/12/vgc-resources.html">Other VGC Resources</a><button class="btn" id="switchTheme">Dark theme</a></span>
+                <span class="header-logo"><a href="http://nimbasacitypost.com"><img src="image_res/Logo Nimbasa City Post White Text PNG.png" alt="Nimbasa City Post" style="height: 45px;padding-top: 5px;" /></a></span><span class="nav"><a href="http://nimbasacitypost.com">Home</a> | <a href="http://play.pokemonshowdown.com/vgc">Showdown</a> | <a href="https://www.porydex.com/stats">Showdown Usage Stats</a> | <a href="https://docs.google.com/spreadsheets/d/1axlwmzPA49rYkqXh7zHvAtSP-TKbM0ijGYBPRflLSWw">VGCPastes Repository</a> | <a href="https://github.com/nerd-of-now/VGC-Damage-Calculator">GitHub Page</a> | <a href="https://www.nimbasacitypost.com/2019/12/vgc-resources.html">Other VGC Resources</a><button class="btn" id="switchTheme">Dark theme</button></span>
                 <div style="clear:both"></div>
             </div>
         </div>
@@ -52,7 +52,8 @@
                     <input class="gen btn-input" type="radio" name="gen" value="6" id="gen6" /><label class="btn btn-small btn-mid" for="gen6">ORAS</label>
                     <input class="gen btn-input" type="radio" name="gen" value="7" id="gen7" /><label class="btn btn-small btn-mid" for="gen7">USUM</label>
                     <input class="gen btn-input" type="radio" name="gen" value="8" id="gen8" checked="checked" /><label class="btn btn-small btn-right" for="gen8">SWSH</label>
-                    <!--<input class="gen btn-input" type="radio" name="gen" value="84" id="gen4re" /><label class="btn btn-small btn-right" for="gen4re">BDSP</label>-->
+                    <!--<input class="gen btn-input" type="radio" name="gen" value="8" id="gen8" /><label class="btn btn-small btn-mid" for="gen8">SWSH</label>
+                    <input class="gen btn-input" type="radio" name="gen" value="9" id="gen9" checked="checked" /><label class="btn btn-small btn-right" for="gen9">S/V</label>-->
                 </span>
             </div>
             <hr />
@@ -120,6 +121,10 @@
                             <select class="type1 terrain-trigger calc-trigger"></select>
                             <select class="type2 terrain-trigger calc-trigger"></select>
                         </div>
+                        <div class="gen-specific g9">
+                            <label>Tera Type</label>
+                            <select class="tera-type calc-trigger gen-specific g9"></select>
+                        </div>
                         <div class="hide">
                             <label>Forme</label>
                             <select class="forme calc-trigger"></select>
@@ -135,27 +140,28 @@
                     </div>
                     <div class="info-group">
                         <table>
-                            <tr><th></th><th>Base</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g84">IVs</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g84">EVs</th><th class="gen-specific g1 g2 hide">DVs</th><th></th><th></th></tr>
-                            <tr class="hp"><td><label>HP</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">341</span></td><td></td></tr>
-                            <tr class="at"><td><label>Attack</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="df"><td><label>Defense</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g84"><td><label>Sp. Atk</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sd gen-specific g2 g3 g4 g5 g6 g7 g8 g84"><td><label>Sp. Def</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr><th></th><th>Base</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g9">IVs</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g9">EVs</th><th class="gen-specific g1 g2 hide">DVs</th><th></th><th></th></tr>
+                            <tr class="hp"><td><label>HP</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">341</span></td><td></td></tr>
+                            <tr class="at"><td><label>Attack</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="df"><td><label>Defense</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g9"><td><label>Sp. Atk</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="sd gen-specific g2 g3 g4 g5 g6 g7 g8 g9"><td><label>Sp. Def</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
                             <tr class="sl gen-specific g1 hide"><td><label>Special</label></td><td><input class="base calc-trigger" value="100" /></td><td><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sp"><td><label>Speed</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td><td><span class="p1-speed-mods">236</span></td></tr>
+                            <tr class="sp"><td><label>Speed</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td><td><span class="p1-speed-mods">236</span></td></tr>
                             <tr><td></td><td></td><td></td><td class='ev-total'>&nbsp;</td><td class='ev-left'>&nbsp;</td><td></td><td></td><td></td></tr>
                         </table>
                     </div>
                     <div class="info-group info-selectors">
-                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g9">
                             <label>Nature</label>
                             <select class="nature calc-trigger"><option value="Adamant">Adamant (+Atk, -SpA)</option><option value="Bashful">Bashful</option><option value="Bold">Bold (+Def, -Atk)</option><option value="Brave">Brave (+Atk, -Spe)</option><option value="Calm">Calm (+SpD, -Atk)</option><option value="Careful">Careful (+SpD, -SpA)</option><option value="Docile">Docile</option><option value="Gentle">Gentle (+SpD, -Def)</option><option value="Hardy" selected="selected">Hardy</option><option value="Hasty">Hasty (+Spe, -Def)</option><option value="Impish">Impish (+Def, -SpA)</option><option value="Jolly">Jolly (+Spe, -SpA)</option><option value="Lax">Lax (+Def, -SpD)</option><option value="Lonely">Lonely (+Atk, -Def)</option><option value="Mild">Mild (+SpA, -Def)</option><option value="Modest">Modest (+SpA, -Atk)</option><option value="Naive">Naive (+Spe, -SpD)</option><option value="Naughty">Naughty (+Atk, -SpD)</option><option value="Quiet">Quiet (+SpA, -Spe)</option><option value="Quirky">Quirky</option><option value="Rash">Rash (+SpA, -SpD)</option><option value="Relaxed">Relaxed (+Def, -Spe)</option><option value="Sassy">Sassy (+SpD, -Spe)</option><option value="Serious">Serious</option><option value="Timid">Timid (+Spe, -Atk)</option></select>
                         </div>
-                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g9">
                             <label>Ability</label>
                             <select class="ability terrain-trigger calc-trigger"></select>
+                            <input class="abilityToggle calc-trigger hide" type="checkbox" title="Is this Ability active?">
                         </div>
-                        <div class="gen-specific g2 g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g2 g3 g4 g5 g6 g7 g8 g9">
                             <label>Item</label>
                             <select class="item terrain-trigger calc-trigger"></select>
                         </div>
@@ -169,50 +175,60 @@
                         <label>Current HP</label>
                         <input class="current-hp calc-trigger" value="341" />/<span class="max-hp">341</span> (<input class="percent-hp calc-trigger" value="100" />%)
                         <input class="max move-max calc-trigger btn-input" type="checkbox" id="maxL" /><label class="btn btn-wide gen-specific g8" for="maxL" title="Dynamax this Pokemon?">Dynamax</label>
+                        <input class="tera move-tera calc-trigger btn-input" type="checkbox" id="teraL" /><label class="btn btn-wide gen-specific g9" for="teraL" title="Terastalize this Pokemon?">Terastal</label>
+                        <!--<select class="tera-type calc-trigger gen-specific g9"></select>-->
                     </div>
                     <div class="move1">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="50" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL1" /><label class="btn crit-btn" for="critL1" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zL1" /><label class="btn x-btn gen-specific g7" for="zL1" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move2">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL2" /><label class="btn crit-btn" for="critL2" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zL2" /><label class="btn x-btn gen-specific g7" for="zL2" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move3">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL3" /><label class="btn crit-btn" for="critL3" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zL3" /><label class="btn x-btn gen-specific g7" for="zL3" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move4">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critL4" /><label class="btn crit-btn" for="critL4" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zL4" /><label class="btn x-btn gen-specific g7" for="zL4" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="info-group">
                         <input type="text" id="setName1" style="width: 25%" value="My Calc Set">
@@ -239,19 +255,19 @@
                 </div>
                 <div class="panel-body">
                     <!--<img id="toge" align="center" src="image_res/toge_normal.png" height="150" alt="The Face of God, Colorized (2020)" style="display: block;  margin: 0 auto;">-->
-                    <div class="gen-specific g3 g4 g5 g6 g7 g8 g84" style="width: 11em; margin: 0 auto 5px;" title="Select the battle format.">
+                    <div class="gen-specific g3 g4 g5 g6 g7 g8 g9" style="width: 11em; margin: 0 auto 5px;" title="Select the battle format.">
                         <input class="btn-input calc-trigger" type="radio" name="format" value="Singles" id="singles" checked="checked" /><label class="btn btn-left" for="singles">Singles</label>
                         <input class="btn-input calc-trigger" type="radio" name="format" value="Doubles" id="doubles" /><label class="btn btn-right" for="doubles">Doubles</label>
                     </div>
-                    <div class="gen-specific g6 g7 g8 g84" style="width: 23.0em; margin: 5px auto;" title="Select the current terrain.">
+                    <div class="gen-specific g6 g7 g8 g9" style="width: 23.0em; margin: 5px auto;" title="Select the current terrain.">
                         <input class="btn-input terrain-trigger calc-trigger" type="radio" name="terrain" value="" id="noterrain" checked="checked" /><label class="btn btn-small btn-left" for="noterrain">None</label>
                         <input class="btn-input terrain-trigger calc-trigger" type="radio" name="terrain" value="Electric" id="electric" /><label class="btn btn-small btn-mid" for="electric">Electric</label>
                         <input class="btn-input terrain-trigger calc-trigger" type="radio" name="terrain" value="Grassy" id="grassy" /><label class="btn btn-small btn-mid" for="grassy">Grassy</label>
                         <input class="btn-input terrain-trigger calc-trigger" type="radio" name="terrain" value="Misty" id="misty" /><label class="btn btn-small btn-mid" for="misty">Misty</label>
                         <input class="btn-input terrain-trigger calc-trigger" type="radio" name="terrain" value="Psychic" id="psychic" /><label class="btn btn-small btn-right" for="psychic">Psychic</label>
                     </div>
-                    <hr class="gen-specific g6 g7 g8 g84" />
-                    <div class="gen-specific g3 g4 g5 g6 g7 g8 g84" style="width: 23em; margin: 5px auto;" title="Select the current weather condition.">
+                    <hr class="gen-specific g6 g7 g8 g9" />
+                    <div class="gen-specific g3 g4 g5 g6 g7 g8 g9" style="width: 23em; margin: 5px auto;" title="Select the current weather condition.">
                         <input class="btn-input calc-trigger" type="radio" name="weather" value="" id="clear" checked="checked" /><label class="btn btn-small btn-left" for="clear">None</label>
                         <input class="btn-input calc-trigger" type="radio" name="weather" value="Sun" id="sun" /><label class="btn btn-small btn-mid" for="sun">Sun</label>
                         <input class="btn-input calc-trigger" type="radio" name="weather" value="Rain" id="rain" /><label class="btn btn-small btn-mid" for="rain">Rain</label>
@@ -269,18 +285,30 @@
                         <input class="btn-input calc-trigger" type="radio" name="gscWeather" value="Rain" id="gscRain" /><label class="btn btn-small btn-mid" for="gscRain">Rain</label>
                         <input class="btn-input calc-trigger" type="radio" name="gscWeather" value="Sand" id="gscSand" /><label class="btn btn-small btn-right" for="gscSand">Sand</label>
                     </div>
-                    <div class="gen-specific g6 g7 g8" style="width: 23em; margin: 5px auto;" title="Select the current radiating aura.">
+                    <div class="gen-specific g6 g7 g8 g9" style="width: 23em; margin: 5px auto;" title="Select the current radiating aura.">
                         <input class="btn-input calc-trigger" type="checkbox" name="aura" value="Aura Break" id="aura-break" /><label class="btn btn-wide btn-left" for="aura-break">Aura Break</label>
                         <input class="btn-input calc-trigger" type="checkbox" name="aura" value="Fairy Aura" id="fairy-aura" /><label class="btn btn-wide btn-mid" for="fairy-aura">Fairy Aura</label>
                         <input class="btn-input calc-trigger" type="checkbox" name="aura" value="Dark Aura" id="dark-aura" /><label class="btn btn-wide btn-right" for="dark-aura">Dark Aura</label>
                     </div>
-                    <div class="gen-specific g4 g5 g6 g7 g8 g84" style="width: 5.3em; margin: 5px auto;" title="Is gravity in effect?">
-                        <input class="btn-input calc-trigger" type="checkbox" id="gravity" /><label class="btn" for="gravity">Gravity</label>
+                    <!--<div class="gen-specific g4 g5 g6 g7 g8 g9" style="width: 5.3em; margin: 5px auto;" title="Is gravity in effect?">
+                    <input class="btn-input calc-trigger" type="checkbox" id="gravity" /><label class="btn" for="gravity">Gravity</label>
+                </div>-->
+                    <!--<div class="gen-specific g8 g9" style="width: 5.3em; margin: 5px auto;" title="Is neutralizing gas in effect?">
+                    <input class="btn-input calc-trigger" type="checkbox" id="neutralizingGas" /><label class="btn btn-xwide" for="neutralizingGas">Neutralizing Gas</label>
+                </div>-->
+                    <div class="gen-specific g4 g5 g6 g7 g8 g9" style="width: 14.6em; margin: 5px auto;">
+                        <div class="gen-specific g4 g5 g6 g7 divider">
+                            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                        </div>
+                        <input class="btn-input calc-trigger" type="checkbox" id="gravity" /><label class="btn" for="gravity" title="Is gravity in effect?">Gravity</label>
+                        <div class="gen-specific g8 g9 divider">
+                            &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+                            <input class="btn-input calc-trigger" type="checkbox" id="neutralizingGas" /><label class="btn btn-xwide" for="neutralizingGas" title="Is neutralizing gas in effect?">Neutralizing Gas </label>
+                        </div>
                     </div>
-                    <div class="gen-specific g8 g84" style="width: 5.3em; margin: 5px auto;" title="Is neutralizing gas in effect?">
-                        <input class="btn-input calc-trigger" type="checkbox" id="neutralizingGas" /><label class="btn btn-xwide" for="neutralizingGas">Neutralizing Gas</label>
-                    </div>
-                    <hr class="gen-specific g2 g3 g4 g5 g6 g7 g8 g84" />
+                    <!-- Note: I know the html is clunky but it does make it look nicer so idk probably worth
+                       I have the original code commented out anyways if I change my mind -->
+                    <hr class="gen-specific g2 g3 g4 g5 g6 g7 g8 g9" />
                     <div class="btn-group gen-specific g7 g8">
                         <div class="left" title="Is this Pokemon protecting?">
                             <input class="btn-input calc-trigger" type="checkbox" id="protectL" /><label class="btn btn-xwide" for="protectL">Protect</label>
@@ -289,7 +317,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="protectR" /><label class="btn btn-xwide" for="protectR">Protect</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g3 g4 g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g3 g4 g5 g6 g7 g8 g9">
                         <div class="left" title="Has this Pokemon's power been boosted by an ally's Helping Hand?">
                             <input class="btn-input calc-trigger" type="checkbox" id="helpingHandL" /><label class="btn btn-xxwide" for="helpingHandL">Helping Hand</label>
                         </div>
@@ -315,7 +343,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="weakR" /><label class="btn btn-xwide" for="weakR"><img src="image_res/Weakness_Policy.png"><br>Weakness Policy</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g9">
                         <div class="left" title="Has Tailwind been set?">
                             <input class="btn-input calc-trigger" type="checkbox" id="tailwindL" /><label class="btn btn-xwide" for="tailwindL">Tailwind</label>
                         </div>
@@ -331,7 +359,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="gMaxFieldR" /><label class="btn btn-xwide" for="gMaxFieldR">G-Max Field</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g5 g6 g7 g8 g9">
                         <div class="left" title="Is this Pokemon protected by an ally's Friend Guard?">
                             <input class="btn-input calc-trigger" type="checkbox" id="friendGuardL" /><label class="btn btn-xxwide" for="friendGuardL">Friend Guard</label>
                         </div>
@@ -339,7 +367,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="friendGuardR" /><label class="btn btn-xxwide" for="friendGuardR">Friend Guard</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g9">
                         <div class="left" title="Does this Pokemon's ally have Flower Gift?">
                             <input class="btn-input calc-trigger" type="checkbox" id="flowerGiftL" /><label class="btn btn-xxwide" for="flowerGiftL">Flower Gift</label>
                         </div>
@@ -347,7 +375,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="flowerGiftR" /><label class="btn btn-xxwide" for="flowerGiftR">Flower Gift</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g8">
+                    <div class="btn-group gen-specific g8 g9">
                         <div class="left" title="Does this Pokemon's ally have Steely Spirit?">
                             <input class="btn-input calc-trigger" type="checkbox" id="steelySpiritL" /><label class="btn btn-xxwide" for="steelySpiritL">Steely Spirit</label>
                         </div>
@@ -355,7 +383,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="steelySpiritR" /><label class="btn btn-xxwide" for="steelySpiritR">Steely Spirit</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g8">
+                    <div class="btn-group gen-specific g8 g9">
                         <div class="left" title="Is this Pokemon boosted by an ally's Power Spot?">
                             <input class="btn-input calc-trigger" type="checkbox" id="powerSpotL" /><label class="btn btn-xxwide" for="powerSpotL">Power Spot</label>
                         </div>
@@ -363,7 +391,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="powerSpotR" /><label class="btn btn-xxwide" for="powerSpotR">Power Spot</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g7 g8">
+                    <div class="btn-group gen-specific g7 g8 g9">
                         <div class="left" title="Has this Pokemon's power been boosted by an ally's Battery?">
                             <input class="btn-input calc-trigger" type="checkbox" id="batteryL" /><label class="btn btn-xxwide" for="batteryL">Battery</label>
                         </div>
@@ -387,7 +415,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="evoR" /><label class="btn btn-xwide" for="evoR"><img src="image_res/133.png"><br>Extreme Evoboost</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g4 g5 g6 g7 g8 g9">
                         <div class="left" title="Is Stealth Rock affecting this side of the field?">
                             <input class="btn-input calc-trigger" type="checkbox" id="srL" /><label class="btn btn-xwide" for="srL">Stealth Rock</label>
                         </div>
@@ -395,7 +423,7 @@
                             <input class="btn-input calc-trigger" type="checkbox" id="srR" /><label class="btn btn-xwide" for="srR">Stealth Rock</label>
                         </div>
                     </div>
-                    <div class="btn-group gen-specific g3 g4 g5 g6 g7 g8 g84">
+                    <div class="btn-group gen-specific g3 g4 g5 g6 g7 g8 g9">
                         <div class="left" title="Are there Spikes on this side of the field?">
                             <input class="btn-input calc-trigger" type="radio" name="spikesL" value="0" id="spikesL0" checked="checked" /><label class="btn btn-xsmall btn-left" for="spikesL0">0</label>
                             <input class="btn-input calc-trigger" type="radio" name="spikesL" value="1" id="spikesL1" /><label class="btn btn-xsmall btn-mid" for="spikesL1">1</label>
@@ -445,6 +473,10 @@
                             <select class="type1 terrain-trigger calc-trigger"></select>
                             <select class="type2 terrain-trigger calc-trigger"></select>
                         </div>
+                        <div class="gen-specific g9">
+                            <label>Tera Type</label>
+                            <select class="tera-type calc-trigger gen-specific g9"></select>
+                        </div>
                         <div class="hide">
                             <label>Forme</label>
                             <select class="forme calc-trigger"></select>
@@ -460,27 +492,28 @@
                     </div>
                     <div class="info-group">
                         <table>
-                            <tr><th></th><th>Base</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g84">IVs</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g84">EVs</th><th class="gen-specific g1 g2 hide">DVs</th><th></th><th></th></tr>
-                            <tr class="hp"><td><label>HP</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">341</span></td><td></td></tr>
-                            <tr class="at"><td><label>Attack</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="df"><td><label>Defense</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g84"><td><label>Sp. Atk</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sd gen-specific g2 g3 g4 g5 g6 g7 g8 g84"><td><label>Sp. Def</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr><th></th><th>Base</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g9">IVs</th><th class="gen-specific g3 g4 g5 g6 g7 g8 g9">EVs</th><th class="gen-specific g1 g2 hide">DVs</th><th></th><th></th></tr>
+                            <tr class="hp"><td><label>HP</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">341</span></td><td></td></tr>
+                            <tr class="at"><td><label>Attack</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="df"><td><label>Defense</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="sa gen-specific g2 g3 g4 g5 g6 g7 g8 g9"><td><label>Sp. Atk</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
+                            <tr class="sd gen-specific g2 g3 g4 g5 g6 g7 g8 g9"><td><label>Sp. Def</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" disabled="disabled" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
                             <tr class="sl gen-specific g1 hide"><td><label>Special</label></td><td><input class="base calc-trigger" value="100" /></td><td><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td></tr>
-                            <tr class="sp"><td><label>Speed</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g84"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td><td><span class="p2-speed-mods">236</span></td></tr>
+                            <tr class="sp"><td><label>Speed</label></td><td><input class="base calc-trigger" value="100" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="ivs calc-trigger" value="31" /></td><td class="gen-specific g3 g4 g5 g6 g7 g8 g9"><input class="evs calc-trigger" type="number" min="0" max="252" step="4" value="0" /></td><td class="gen-specific g1 g2 hide"><input class="dvs calc-trigger" value="15" /></td><td><span class="total">236</span></td><td><select class="boost calc-trigger"><option value="6">+6</option><option value="5">+5</option><option value="4">+4</option><option value="3">+3</option><option value="2">+2</option><option value="1">+1</option><option value="0" selected="selected">--</option><option value="-1">-1</option><option value="-2">-2</option><option value="-3">-3</option><option value="-4">-4</option><option value="-5">-5</option><option value="-6">-6</option></select></td><td><span class="p2-speed-mods">236</span></td></tr>
                             <tr><td></td><td></td><td></td><td class='ev-total'>&nbsp;</td><td class='ev-left'>&nbsp;</td><td></td><td></td><td></td></tr>
                         </table>
                     </div>
                     <div class="info-group info-selectors">
-                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g9">
                             <label>Nature</label>
                             <select class="nature calc-trigger"><option value="Adamant">Adamant (+Atk, -SpA)</option><option value="Bashful">Bashful</option><option value="Bold">Bold (+Def, -Atk)</option><option value="Brave">Brave (+Atk, -Spe)</option><option value="Calm">Calm (+SpD, -Atk)</option><option value="Careful">Careful (+SpD, -SpA)</option><option value="Docile">Docile</option><option value="Gentle">Gentle (+SpD, -Def)</option><option value="Hardy" selected="selected">Hardy</option><option value="Hasty">Hasty (+Spe, -Def)</option><option value="Impish">Impish (+Def, -SpA)</option><option value="Jolly">Jolly (+Spe, -SpA)</option><option value="Lax">Lax (+Def, -SpD)</option><option value="Lonely">Lonely (+Atk, -Def)</option><option value="Mild">Mild (+SpA, -Def)</option><option value="Modest">Modest (+SpA, -Atk)</option><option value="Naive">Naive (+Spe, -SpD)</option><option value="Naughty">Naughty (+Atk, -SpD)</option><option value="Quiet">Quiet (+SpA, -Spe)</option><option value="Quirky">Quirky</option><option value="Rash">Rash (+SpA, -SpD)</option><option value="Relaxed">Relaxed (+Def, -Spe)</option><option value="Sassy">Sassy (+SpD, -Spe)</option><option value="Serious">Serious</option><option value="Timid">Timid (+Spe, -Atk)</option></select>
                         </div>
-                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g3 g4 g5 g6 g7 g8 g9">
                             <label>Ability</label>
                             <select class="ability terrain-trigger calc-trigger"></select>
+                            <input class="abilityToggle calc-trigger hide" type="checkbox" title="Is this Ability active?">
                         </div>
-                        <div class="gen-specific g2 g3 g4 g5 g6 g7 g8 g84">
+                        <div class="gen-specific g2 g3 g4 g5 g6 g7 g8 g9">
                             <label>Item</label>
                             <select class="item terrain-trigger calc-trigger"></select>
                         </div>
@@ -494,50 +527,60 @@
                         <label>Current HP</label>
                         <input class="current-hp calc-trigger" value="341" />/<span class="max-hp">341</span> (<input class="percent-hp calc-trigger" value="100" />%)
                         <input class="max move-max calc-trigger btn-input" type="checkbox" id="maxR" /><label class="btn btn-wide gen-specific g8" for="maxR" title="Dynamax this Pokemon?">Dynamax</label>
+                        <input class="tera move-tera calc-trigger btn-input" type="checkbox" id="teraR" /><label class="btn btn-wide gen-specific g9" for="teraR" title="Terastalize this Pokemon?">Terastal</label>
+                        <!--<select class="tera-type calc-trigger gen-specific g9"></select>-->
                     </div>
                     <div class="move1">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="50" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR1" /><label class="btn crit-btn" for="critR1" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zR1" /><label class="btn x-btn gen-specific g7" for="zR1" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move2">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR2" /><label class="btn crit-btn" for="critR2" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zR2" /><label class="btn x-btn gen-specific g7" for="zR2" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move3">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR3" /><label class="btn crit-btn" for="critR3" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zR3" /><label class="btn x-btn gen-specific g7" for="zR3" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="move4">
                         <select class="move-selector calc-trigger small-select"></select>
                         <input class="move-bp calc-trigger" value="0" />
                         <select class="move-type calc-trigger"></select>
-                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g84"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
+                        <select class="move-cat calc-trigger gen-specific g4 g5 g6 g7 g8 g9"><option value="Physical">Physical</option><option value="Special">Special</option><option value="Status">Status</option></select>
                         <input class="move-crit calc-trigger btn-input" type="checkbox" id="critR4" /><label class="btn crit-btn" for="critR4" title="Force this attack to be a critical hit?">Crit</label>
                         <input class="move-z calc-trigger btn-input" type="checkbox" id="zR4" /><label class="btn x-btn gen-specific g7" for="zR4" title="Use the corresponding Z-Move?">Z-Move</label>
                         <select class="move-hits calc-trigger hide"><option value="2">2 hits</option><option value="3">3 hits</option><option value="4">4 hits</option><option value="5">5 hits</option></select>
                         <select class="move-double calc-trigger hide"><option value="0">Normal BP</option><option value="1">Doubled</option></select>
                         <select class="move-hits2 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option></select>
+                        <select class="move-hits3 calc-trigger hide"><option value="1">1 hit</option><option value="2">2 hits</option><option value="3">3 hits</option></select>
+                        <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                     </div>
                     <div class="info-group">
                         <input type="text" id="setName2" style="width: 25%" value="My Calc Set">
@@ -578,10 +621,12 @@
     <script type="text/javascript" src="script_res/setdex_vgcbfd.js" id="NCPScript"></script>
     <!--<script type="text/javascript" src="script_res/setdex_vgc2022.js" id="NCPScript"></script>-->
     <script type="text/javascript" src="script_res/setdex_ncp-g8.js" id="NCPScript"></script>
+    <script type="text/javascript" src="script_res/setdex_ncp-g9.js" id="NCPScript"></script>
     <script type="text/javascript" src="script_res/setdex_smogon.js" id="SmogScript"></script>
     <script type="text/javascript" src="script_res/setdex_xy.js" id="XYScript"></script>
     <script type="text/javascript" src="script_res/setdex_sm.js" id="SMScript"></script>
     <script type="text/javascript" src="script_res/setdex_ss.js" id="SSScript"></script>
+    <script type="text/javascript" src="script_res/setdex_sv.js" id="SVScript"></script>
     <script type="text/javascript" src="script_res/setdex_bdsp.js" id="BDSPScript"></script>
     <script type="text/javascript" src="script_res/setdex_bw.js"></script>
     <script type="text/javascript" src="script_res/setdex_dpp.js"></script>
@@ -596,7 +641,8 @@
     <script type="text/javascript" src="script_res/item_data.js"></script>
     <script type="text/javascript" src="script_res/move_data.js"></script>
     <script type="text/javascript" src="script_res/ap_calc.js"></script>
-    <script type="text/javascript" src="script_res/damage.js"></script>
+    <script type="text/javascript" src="script_res/damage_MASTER.js"></script>
+    <!--<script type="text/javascript" src="script_res/damage.js"></script>-->
     <script type="text/javascript" src="script_res/damage_sm.js"></script>
     <script type="text/javascript" src="script_res/damage_xy.js"></script>
     <script type="text/javascript" src="script_res/damage_bw.js"></script>

--- a/script_res/ability_data.js
+++ b/script_res/ability_data.js
@@ -8,7 +8,7 @@ var ABILITIES_ADV = [
     'Drizzle',
     'Drought',
     'Flash Fire',
-    'Flash Fire (activated)',
+    //'Flash Fire (activated)',   //make flash fire work and remove this
     'Forecast',
     'Guts',
     'Huge Power',
@@ -35,9 +35,9 @@ var ABILITIES_ADV = [
     //NO FUNCTION IN CALCS
     'Arena Trap',
     'Color Change',
-    'Compoundeyes',
+    'Compound Eyes',
     'Cute Charm',
-    'Damp', //Might implement functionality
+    'Damp', //Functionality in calc I lied
     'Early Bird',
     'Effect Spore',
     'Flame Body',
@@ -51,12 +51,12 @@ var ABILITIES_ADV = [
     'Liquid Ooze',
     'Magma Armor',
     'Magnet Pull',
-    'Minus',   
+    'Minus',    //Functionality in calc I lied
     'Natural Cure',
     'Oblivious',    //Has functionality in a later gen
     'Own Tempo',    //Has functionality in a later gen
     'Pickup',
-    'Plus', 
+    'Plus',  //Functionality in calc I lied
     'Poison Point',
     'Pressure',
     'Rough Skin',
@@ -72,7 +72,7 @@ var ABILITIES_ADV = [
     'Sturdy',
     'Suction Cups',
     'Synchronize',
-    'Trace',    //Might have relevant functionality?
+    'Trace',    //Functionality in calc I lied
     'Truant',
     'Vital Spirit',
     'Water Veil',
@@ -119,14 +119,14 @@ var ABILITIES_DPP = ABILITIES_ADV.concat([
     'Hydration',
     'Leaf Guard',
     'No Guard',
-    'Quick Feet',
+    'Quick Feet',  //Functionality in calc I lied
     'Rivalry',  //Only implement functionality if demand is a lot
     'Stall',
     'Steadfast',
     'Storm Drain',   //Has functionality in a later gen
     'Super Luck',
     'Tangled Feet',
-    'Unburden'
+    'Unburden'  //Functionality in calc I lied
 ]);
 
 var ABILITIES_BW = ABILITIES_DPP.concat([
@@ -154,12 +154,12 @@ var ABILITIES_BW = ABILITIES_DPP.concat([
     'Friend Guard',
     'Harvest',
     'Healer',
-    'Heavy Metal',
+    'Heavy Metal', //Functionality in calc I lied
     'Illusion',
     'Imposter',
     'Iron Barbs',
     'Justified',
-    'Light Metal',
+    'Light Metal', //Functionality in calc I lied
     'Magic Bounce',
     'Moody',
     'Moxie',
@@ -201,7 +201,7 @@ var ABILITIES_XY = ABILITIES_BW.concat([
     'Flower Veil',
     'Gale Wings',
     'Gooey',
-    'Grass Pelt',
+    'Grass Pelt', //Functionality in calc I lied
     'Magician',
     'Stance Change',
     'Sweet Veil',
@@ -278,11 +278,11 @@ var ABILITIES_SS = ABILITIES_SM.concat([
     'Gulp Missile',
     'Hunger Switch',
     'Ice Face',
-    'Mimicry',  //Might implement functionality
+    'Mimicry',  //Functionality in calc I lied
     'Pastel Veil',
     'Perish Body',
     'Propeller Tail',
-    'Sand Spit',    //Maybe implement? idk
+    'Sand Spit',    //Maybe implement with abilityOn? idk
     'Screen Cleaner',   
     'Stalwart',
     'Steam Engine',
@@ -295,3 +295,10 @@ var ABILITIES_SS = ABILITIES_SM.concat([
 ]);
 
 //ABILITIES_XY.splice(ABILITIES_XY.indexOf('Lightning Rod'), 1, 'Lightning Rod');
+var ATE_IZE_ABILITIES = [
+    'Normalize',
+    'Aerilate',
+    'Pixilate',
+    'Refrigerate',
+    'Galvanize',
+];

--- a/script_res/ap_calc.css
+++ b/script_res/ap_calc.css
@@ -43,6 +43,7 @@ th {
     display: inline-block;
 }
 .poke-info {
+    /*width: 33.1em;*/
     width: 30em;
 }
 .field-info {
@@ -140,6 +141,11 @@ th {
     background: #10171e !important;
 }
 
+.divider {
+    width: 5em;
+    display: inline;
+}
+
 
 
 /* header */
@@ -189,7 +195,7 @@ th {
 select.toxic-counter {
     width: 4.5em;
 }
-.move-selector, .move-bp, .move-type, .move-cat, .move-hits, .move-double, .move-hits2 {
+.move-selector, .move-bp, .move-type, .move-cat, .move-hits, .move-double, .move-hits2, .move-hits3, .move-pledge {
     font-size: 0.9em;
 }
 .move-selector {
@@ -198,8 +204,11 @@ select.toxic-counter {
 .poke-info input.move-bp {
     width: 2em;
 }
-.move-cat, .move-hits {
+.move-cat/*, .move-hits*/ {
     width: 4em;
+}
+.move-hits, .move-double, .move-hits2, .move-hits3, .move-pledge {
+    width: 4.6em;
 }
 .poke-info .crit-btn {
     font-size: 0.8em;

--- a/script_res/damage_MASTER.js
+++ b/script_res/damage_MASTER.js
@@ -1,0 +1,1715 @@
+/* Damage calculation for the Generation VIII games: Sword, Shield, Isle of Armor, and Crown Tundra; 
+ * and for the Generation VII games: Sun, Moon, Ultra Sun, and Ultra Moon*/
+
+function CALCULATE_ALL_MOVES_SS(p1, p2, field) {
+    checkTrace(p1, p2);
+    checkTrace(p2, p1);
+    checkNeutralGas(p1, p2, field.getNeutralGas());
+    checkAirLock(p1, field);
+    checkAirLock(p2, field);
+    checkForecast(p1, field.getWeather());
+    checkForecast(p2, field.getWeather());
+    checkMimicry(p1, field.getTerrain());
+    checkMimicry(p2, field.getTerrain());
+    checkKlutz(p1);
+    checkKlutz(p2);
+    checkEvo(p1, p2);
+    checkSeeds(p1, field);
+    checkSeeds(p2, field);
+    checkSwordShield(p1);
+    checkSwordShield(p2);
+    checkIntimidateSS(p1, p2);
+    checkIntimidateSS(p2, p1);
+    p1.stats[DF] = getModifiedStat(p1.rawStats[DF], p1.boosts[DF]);
+    p1.stats[SD] = getModifiedStat(p1.rawStats[SD], p1.boosts[SD]);
+    p1.stats[SP] = getFinalSpeedSS(p1, field.getWeather(), field.getTerrain(), field.getTailwind(0));
+    $(".p1-speed-mods").text(p1.stats[SP]);
+    p2.stats[DF] = getModifiedStat(p2.rawStats[DF], p2.boosts[DF]);
+    p2.stats[SD] = getModifiedStat(p2.rawStats[SD], p2.boosts[SD]);
+    p2.stats[SP] = getFinalSpeedSS(p2, field.getWeather(), field.getTerrain(), field.getTailwind(1));
+    $(".p2-speed-mods").text(p2.stats[SP]);
+    checkDownload(p1, p2);
+    checkDownload(p2, p1);
+    p1.stats[AT] = getModifiedStat(p1.rawStats[AT], p1.boosts[AT]);
+    p1.stats[SA] = getModifiedStat(p1.rawStats[SA], p1.boosts[SA]);
+    p2.stats[AT] = getModifiedStat(p2.rawStats[AT], p2.boosts[AT]);
+    p2.stats[SA] = getModifiedStat(p2.rawStats[SA], p2.boosts[SA]);
+    var side1 = field.getSide(1);
+    var side2 = field.getSide(0);
+    checkInfiltrator(p1, side1);
+    checkInfiltrator(p2, side2);
+    getWeightMods(p1, p2);
+    var results = [[],[]];
+    for (var i = 0; i < 4; i++) {
+        results[0][i] = GET_DAMAGE_SS(p1, p2, p1.moves[i], side1);
+        results[1][i] = GET_DAMAGE_SS(p2, p1, p2.moves[i], side2);
+    }
+    return results;
+}
+
+function GET_DAMAGE_SS(attacker, defender, move, field) {
+    var moveDescName = move.name;
+    var isQuarteredByProtect = false;
+
+    checkMoveTypeChange(move, field, attacker);
+
+    if (attacker.isDynamax)
+        [move, isQuarteredByProtect, moveDescName] = MaxMoves(move, attacker, isQuarteredByProtect, moveDescName, field);
+
+    if (move.name == "Nature Power")
+        [move, moveDescName] = NaturePower(move, field, moveDescName);
+
+    if (move.isZ || move.isSignatureZ)
+        [move, isQuarteredByProtect, moveDescName] = ZMoves(move, field, attacker, isQuarteredByProtect, moveDescName);
+
+    attacker_name = attacker.name;
+    if (attacker_name && attacker_name.includes("-Gmax")) attacker_name = attacker_name.substring(0, attacker_name.indexOf('-Gmax'));
+    defender_name = defender.name;
+    if (defender_name && defender_name.includes("-Gmax")) defender_name = defender_name.substring(0, defender_name.indexOf('-Gmax'));
+    var description = {
+        "attackerName": attacker_name,
+        "moveName": moveDescName,
+        "defenderName": defender_name
+    };
+
+    if (move.bp === 0 || move.category === "Status") {
+        return statusMoves(move, attacker, defender, description);
+    }
+
+    var defAbility = defender.ability;
+    [defAbility, description] = abilityIgnore(attacker, move, defAbility, description);
+
+    var isCritical = critMove(move, defAbility);
+
+    if (move.name == "Aura Wheel" && attacker.name == "Morpeko-Hangry") {
+        move.type = AuraWheel(move, attacker);
+    }
+
+    var ateIzeAbility = ATE_IZE_ABILITIES.indexOf(attacker.ability);    //Confirms abilities like Normalize and Pixilate but not Liquid Voice
+    var ateIzeBoosted;
+    if (!move.isZ && (ateIzeAbility !== -1 || attacker.ability == "Liquid Voice")
+        && (gen <= 4 || ['Hidden Power', 'Weather Ball', 'Natural Gift', 'Judgement', 'Techno Blast', 'Revelation Dance', 'Multi-Attack', 'Terrain Pulse'].indexOf(move.type) !== -1)) {
+        [move, description, ateIzeBoosted] = ateIzeTypeChange(move, attacker, description);
+    }
+
+    var typeEffect1 = getMoveEffectiveness(move, defender.type1, defender.type2, attacker.ability === "Scrappy" || field.isForesight, field.isGravity, field.weather === "Strong Winds");
+    var typeEffect2 = defender.type2 ? getMoveEffectiveness(move, defender.type2, defender.type1, attacker.ability === "Scrappy" || field.isForesight, field.isGravity, field.weather === "Strong Winds") : 1;
+    var typeEffectiveness = typeEffect1 * typeEffect2;
+    immuneBuildDesc = immunityChecks(move, attacker, defender, field, description, defAbility, typeEffectiveness);
+    if (immuneBuildDesc !== -1) return immuneBuildDesc;
+
+    description.HPEVs = defender.HPEVs + " HP";
+
+    setDamageBuildDesc = setDamage(move, attacker, defender, description, isQuarteredByProtect);
+    if (setDamageBuildDesc !== -1) return setDamageBuildDesc;
+
+    if (move.hits > 1) {
+        description.hits = move.hits;
+    }
+    var turnOrder = attacker.stats[SP] > defender.stats[SP] ? "FIRST" : "LAST";
+    var attIsGrounded = pIsGrounded(attacker, field);
+    var defIsGrounded = pIsGrounded(defender, field);
+
+    ////////////////////////////////
+    ////////// BASE POWER //////////
+    ////////////////////////////////
+    var basePower;
+    [basePower, description] = basePowerFunc(move, description, turnOrder, attacker, defender, field, attIsGrounded, defIsGrounded, defAbility);
+
+    var bpMods;
+    [bpMods, description, move] = calcBPMods(attacker, defender, field, move, description, ateIzeBoosted, basePower, attIsGrounded, defIsGrounded, turnOrder, defAbility);
+
+    basePower = Math.max(1, pokeRound(basePower * chainMods(bpMods) / 0x1000));
+
+    ////////////////////////////////
+    ////////// (SP)ATTACK //////////
+    ////////////////////////////////
+
+    var necrozmaMove = move.name == "Photon Geyser" || move.name == "Light That Burns the Sky";
+    var smartMove = move.name == "Shell Side Arm";
+
+    var attack;
+    [attack, description] = calcAttack(move, attacker, defender, description, necrozmaMove, smartMove, isCritical, defAbility);
+
+    var atMods;
+    [atMods, description] = calcAtMods(move, attacker, defAbility, description, field);
+
+    attack = Math.max(1, pokeRound(attack * chainMods(atMods) / 0x1000));
+
+    ////////////////////////////////
+    ///////// (SP)DEFENSE //////////
+    ////////////////////////////////
+    var hitsPhysical = move.category === "Physical" || move.dealsPhysicalDamage || (necrozmaMove && attacker.stats[AT] >= attacker.stats[SA]) || (smartMove && (attacker.stats[AT] / defender.stats[DF]) >= (attacker.stats[SA] / defender.stats[SD]));
+
+    var defense;
+    [defense, description] = calcDefense(move, attacker, defender, description, hitsPhysical, isCritical, field);
+
+    var dfMods;
+    [dfMods, description] = calcDefMods(move, defender, field, description, hitsPhysical, defAbility);
+
+    defense = Math.max(1, pokeRound(defense * chainMods(dfMods) / 0x1000));
+
+    ////////////////////////////////
+    //////////// DAMAGE ////////////
+    ////////////////////////////////
+    var baseDamage = calcBaseDamage(attacker, basePower, attack, defense);
+
+
+    return calcGeneralMods(baseDamage, move, attacker, defender, defAbility, field, description, isCritical, typeEffectiveness, isQuarteredByProtect);
+}
+
+function numericSort(a, b) {
+    return a - b;
+}
+
+function buildDescriptionSS(description) {
+    var output = "";
+    if (description.attackBoost) {
+        if (description.attackBoost > 0) {
+            output += "+";
+        }
+        output += description.attackBoost + " ";
+    }
+    output = appendIfSet(output, description.attackEVs);
+    output = appendIfSet(output, description.attackerItem);
+    output = appendIfSet(output, description.attackerAbility);
+
+    if (description.isBurned) {
+        output += "burned ";
+    }
+    output += description.attackerName + " ";
+    if (description.isHelpingHand) {
+        output += "Helping Hand ";
+    }
+    if (description.isPowerSpot) {
+        output += "Power Spot ";
+    }
+    if (description.isBattery) {
+        output += "Battery ";
+    }
+    if (description.isSteelySpirit) {
+        output += "Ally Steely Spirit ";
+    }
+    if (description.isFlowerGiftAtk) {
+        output += "Flower Gift ";
+    }
+    output += description.moveName + " ";
+    if (description.moveBP && description.moveType) {
+        output += "(" + description.moveBP + " BP " + description.moveType + ") ";
+    } else if (description.moveBP) {
+        output += "(" + description.moveBP + " BP) ";
+    } else if (description.moveType) {
+        output += "(" + description.moveType + ") ";
+    }
+    if (description.hits) {
+        output += "(" + description.hits + " hits) ";
+    }
+    output += "vs. ";
+    if (description.defenseBoost) {
+        if (description.defenseBoost > 0) {
+            output += "+";
+        }
+        output += description.defenseBoost + " ";
+    }
+    output = appendIfSet(output, description.HPEVs);
+    if (description.defenseEVs) {
+        output += " / " + description.defenseEVs + " ";
+    }
+    output = appendIfSet(output, description.defenderItem);
+    if (description.isFlowerGiftSpD) {
+        output += " Flower Gift ";
+    }
+    output = appendIfSet(output, description.defenderAbility);
+    if (description.isDynamax) output += " Dynamax ";
+    output += description.defenderName;
+    if (description.weather) {
+        output += " in " + description.weather;
+    } else if (description.terrain) {
+        output += " in " + description.terrain + " Terrain";
+    }
+    if (description.isReflect) {
+        output += " through Reflect";
+    } else if (description.isLightScreen) {
+        output += " through Light Screen";
+    }
+    if (description.isCritical) {
+        output += " on a critical hit";
+    }
+    if (description.isFriendGuard) {
+        output += " with Friend Guard";
+    }
+    if(description.isQuarteredByProtect) {
+        output += " through Protect";
+    }
+
+    return output;
+}
+
+function appendIfSet(str, toAppend) {
+    if (toAppend) {
+        return str + toAppend + " ";
+    }
+    return str;
+}
+
+function toSmogonStat(stat) {
+    return stat === AT ? "Atk"
+            : stat === DF ? "Def"
+            : stat === SA ? "SpA"
+            : stat === SD ? "SpD"
+            : stat === SP ? "Spe"
+            : "wtf";
+}
+
+function chainMods(mods) {
+    var M = 0x1000;
+    for(var i = 0; i < mods.length; i++) {
+        if(mods[i] !== 0x1000) {
+            M = Math.round((M * mods[i]) / 0x1000);
+        }
+    }
+    return M;
+}
+
+function getMoveEffectiveness(move, type, otherType, isGhostRevealed, isGravity, isStrongWinds) {
+    if (isGhostRevealed && type === "Ghost" && (move.type === "Normal" || move.type === "Fighting")) {
+        return 1;
+    } else if (isGravity && type === "Flying" && move.type === "Ground") {
+        return 1;
+    } else if(!isGravity && type== "Flying" && move.type === "Ground" && move.name == "Thousand Arrows") {
+        return 1;
+    } else if(!isGravity && otherType == "Flying" && move.type === "Ground" && move.name == "Thousand Arrows") {
+        return 1;
+    } else if (move.name === "Freeze-Dry" && type === "Water") {
+        return 2;
+    } else if (move.name === "Flying Press") {
+        return typeChart["Fighting"][type] * typeChart["Flying"][type];
+    } else if (isStrongWinds && type == "Flying" && typeChart[move.type][type] > 1) {
+        return 1;
+    } else {
+        return typeChart[move.type][type];
+    }
+}
+
+function getModifiedStat(stat, mod) {
+    return mod > 0 ? Math.floor(stat * (2 + mod) / 2)
+            : mod < 0 ? Math.floor(stat * 2 / (2 - mod))
+            : stat;
+}
+
+//Speed Mods
+function getFinalSpeedSS(pokemon, weather, terrain, tailwind) {
+    //1. Speed boosts and drops
+    var speed = getModifiedStat(pokemon.rawStats[SP], pokemon.boosts[SP]);
+    //2. Other Speed mods
+    var otherSpeedMods = 1;
+    //a. Scarf
+    if (pokemon.item === "Choice Scarf" && !pokemon.isDynamax) {
+        otherSpeedMods *= 1.5;
+    } //b. Macho Brace, Iron Ball, Power items
+    else if (["Macho Brace", "Iron Ball", "Power Anklet", "Power Band", "Power Belt", "Power Bracer", "Power Lens", "Power Weight"].indexOf(pokemon.item) !== -1) {
+        otherSpeedMods *= 0.5;
+    } //c. Quick Powder
+    else if (pokemon.name === "Ditto" && pokemon.item === "Quick Powder") {
+        otherSpeedMods *= 2;
+    }
+    //d. Quick Feet
+    if (pokemon.ability === "Quick Feet" && pokemon.status !== "Healthy")
+    {
+        otherSpeedMods *= 1.5;
+    } //e. Slow Start
+    else if (pokemon.ability === "Slow Start")
+    {
+        otherSpeedMods *= 0.5;
+    } //f. 2x Abilities
+    else if ((((pokemon.ability === "Chlorophyll" && weather.indexOf("Sun") > -1) ||
+            (pokemon.ability === "Swift Swim" && weather.indexOf("Rain") > -1)) && pokemon.item !== 'Utility Umbrella') ||
+            (pokemon.ability === "Sand Rush" && weather === "Sand") ||
+            (pokemon.ability === "Slush Rush" && weather.indexOf("Hail") > -1) ||
+            (pokemon.ability === "Surge Surfer" && terrain === "Electric") ||
+            (pokemon.ability === "Unburden" && pokemon.item === "")) {
+        otherSpeedMods *= 2;
+    }
+    //g. Tailwind
+    if (tailwind) otherSpeedMods *= 2;
+
+    speed = pokeRound(speed * otherSpeedMods);
+
+    //3. Paralysis
+    if (pokemon.status === "Paralyzed" && pokemon.ability !== "Quick Feet") {
+        speed = Math.floor(speed / 2);
+    }
+    //4. 65536 Speed check
+    if (speed > 65535) { speed %= 65536; }
+    //5. 10000 Speed check
+    if (speed > 10000) { speed = 10000; }
+    return speed;
+}
+
+function checkTrace(source, target) {
+    if (source.ability === "Trace" && source.abilityOn) {
+        source.ability = target.ability;
+    }
+}
+
+function checkNeutralGas(p1, p2, isNGas) {
+    if (isNGas) {
+        if (p1.ability != "As One" || p1.ability != "RKS System" || p1.ability != "Multitype") p1.ability = "";
+        if (p2.ability != "As One" || p2.ability != "RKS System" || p2.ability != "Multitype") p2.ability = "";
+    }
+}
+function checkAirLock(pokemon, field) {
+    if (pokemon.ability === "Air Lock" || pokemon.ability === "Cloud Nine") {
+        field.clearWeather();
+    }
+}
+function checkForecast(pokemon, weather) {
+    if (pokemon.ability === "Forecast" && pokemon.name === "Castform") {
+        if (weather.indexOf("Sun") > -1) {
+            pokemon.type1 = "Fire";
+        } else if (weather.indexOf("Rain") > -1) {
+            pokemon.type1 = "Water";
+        } else if (weather === "Hail") {
+            pokemon.type1 = "Ice";
+        } else {
+            pokemon.type1 = "Normal";
+        }
+        pokemon.type2 = "";
+    }
+}
+function checkMimicry(pokemon, terrain) {
+    if (pokemon.ability === "Mimicry" && terrain !== "") {
+        pokemon.type1 = terrain === "Electric" ? 'Electric'
+            : terrain === "Grassy" ? 'Grass'
+                : terrain === "Misty" ? 'Fairy'
+                    : 'Psychic';
+        pokemon.type2 = '';
+    }
+}
+function checkKlutz(pokemon) {
+    if (pokemon.ability === "Klutz") {
+        pokemon.item = "";
+    }
+}
+
+function checkSeeds(pokemon, field) {
+    if ((pokemon.item === "Psychic Seed" && field.terrain === "Psychic") || (pokemon.item === "Misty Seed" && field.terrain === "Misty")){
+        pokemon.boosts[SD] = Math.min(6, pokemon.boosts[SD] + 1);
+    }
+    else if ((pokemon.item === "Electric Seed" && field.terrain === "Electric") || (pokemon.item === "Grassy Seed" && field.terrain === "Grassy")) {
+        pokemon.boosts[DF] = Math.min(6, pokemon.boosts[DF] + 1);
+    }
+}
+function checkIntimidateSS(source, target) {    //temporary solution
+    if (source.ability === "Intimidate" && source.abilityOn) {
+        if (target.ability === "Contrary" || target.ability === "Defiant") {
+            target.boosts[AT] = Math.min(6, target.boosts[AT] + 1);
+        } else if (["Clear Body", "White Smoke", "Hyper Cutter", "Full Metal Body"].indexOf(target.ability) !== -1 ||
+            (["Inner Focus", "Oblivious", "Own Tempo", "Scrappy"].indexOf(target.ability) !== -1 && gen >= 8)) {
+            // no effect
+        } else if (target.ability === "Simple") {
+            target.boosts[AT] = Math.max(-6, target.boosts[AT] - 2);
+        } else if (target.ability === "Mirror Armor") {
+            source.boosts[AT] = Math.max(-6, source.boosts[AT] - 1);
+        } else {
+            target.boosts[AT] = Math.max(-6, target.boosts[AT] - 1);
+            if (target.ability === "Competitive") {
+                target.boosts[SA] = Math.min(6, target.boosts[SA] + 2);
+            }
+        }
+        if (target.item === "Adrenaline Orb")
+            target.boosts[SP] = Math.min(6, target.boosts[SP] + 1);
+    }
+}
+function checkSwordShield(pokemon) {
+    if (pokemon.ability === "Intrepid Sword") {
+        pokemon.boosts[AT] = Math.min(6, pokemon.boosts[AT] + 1);
+    }
+    else if (pokemon.ability === "Dauntless Shield") {
+        pokemon.boosts[DF] = Math.min(6, pokemon.boosts[DF] + 1);
+    }
+}
+function checkEvo(p1, p2){
+    if($('#evoL').prop("checked")){
+        p1.boosts[AT] = Math.min(6, p1.boosts[AT] + 2);
+        p1.boosts[DF] = Math.min(6, p1.boosts[DF] + 2);
+        p1.boosts[SA] = Math.min(6, p1.boosts[SA] + 2);
+        p1.boosts[SD] = Math.min(6, p1.boosts[SD] + 2);
+        p1.boosts[SP] = Math.min(6, p1.boosts[SP] + 2);
+    }
+    if($('#evoR').prop("checked")){
+        p2.boosts[AT] = Math.min(6, p2.boosts[AT] + 2);
+        p2.boosts[DF] = Math.min(6, p2.boosts[DF] + 2);
+        p2.boosts[SA] = Math.min(6, p2.boosts[SA] + 2);
+        p2.boosts[SD] = Math.min(6, p2.boosts[SD] + 2);
+        p2.boosts[SP] = Math.min(6, p2.boosts[SP] + 2);
+    }
+
+    if($('#clangL').prop("checked")){
+        p1.boosts[SA] = Math.min(6, p1.boosts[SA] + 2);
+        p1.boosts[SD] = Math.min(6, p1.boosts[SD] + 2);
+        p1.boosts[SP] = Math.min(6, p1.boosts[SP] + 2);
+    }
+    if($('#clangR').prop("checked")){
+        p2.boosts[SA] = Math.min(6, p2.boosts[SA] + 2);
+        p2.boosts[SD] = Math.min(6, p2.boosts[SD] + 2);
+        p2.boosts[SP] = Math.min(6, p2.boosts[SP] + 2);
+    }
+    if ($('#weakL').prop("checked")) {
+        p1.boosts[AT] = Math.min(6, p1.boosts[AT] + 2);
+        p1.boosts[SA] = Math.min(6, p1.boosts[SA] + 2);
+    }
+    if ($('#weakR').prop("checked")) {
+        p2.boosts[AT] = Math.min(6, p2.boosts[AT] + 2);
+        p2.boosts[SA] = Math.min(6, p2.boosts[SA] + 2);
+    }
+
+}
+
+function checkDownload(source, target) {
+    if (source.ability === "Download") {
+        if (target.stats[SD] <= target.stats[DF]) {
+            source.boosts[SA] = Math.min(6, source.boosts[SA] + 1);
+        } else {
+            source.boosts[AT] = Math.min(6, source.boosts[AT] + 1);
+        }
+    }
+}
+function checkInfiltrator(attacker, affectedSide) {
+    if (attacker.ability === "Infiltrator") {
+        affectedSide.isReflect = false;
+        affectedSide.isLightScreen = false;
+    }
+}
+
+function countBoosts(boosts) {
+    var sum = 0;
+    for (var i = 0; i < STATS.length; i++) {
+        if (boosts[STATS[i]] > 0) {
+            sum += boosts[STATS[i]];
+        }
+    }
+    return sum;
+}
+
+// GameFreak rounds DOWN on .5
+function pokeRound(num) {
+    return (num % 1 > 0.5) ? Math.ceil(num) : Math.floor(num);
+}
+
+function getWeightMods(p1, p2) {
+    if (p1.ability == "Heavy Metal") p1.weight *= 2;
+    else if (p1.ability == "Light Metal") p1.weight /= 2;
+
+    if (p2.ability == "Heavy Metal") p2.weight *= 2;
+    else if (p2.ability == "Light Metal") p2.weight /= 2;
+
+    if (p1.item == "Float Stone") p1.weight /= 2;
+    if (p2.item == "Float Stone") p2.weight /= 2;
+}
+
+function checkMoveTypeChange(move, field, attacker) {
+    if (move.name == "Weather Ball") {
+        move.type = field.weather.indexOf("Sun") > -1 && attacker.item !== 'Utility Umbrella' ? "Fire"
+            : field.weather.indexOf("Rain") > -1 && attacker.item !== 'Utility Umbrella' ? "Water"
+                : field.weather === "Sand" ? "Rock"
+                    : field.weather === "Hail" ? "Ice"
+                        : "Normal";
+    }
+    else if (move.name == "Terrain Pulse" || move.name == "Nature Power") {
+        move.type = field.terrain === "Electric" ? "Electric"
+            : field.terrain === "Grassy" ? "Grass"
+                : field.terrain === "Misty" ? "Fairy"
+                    : field.terrain === "Psychic" ? "Psychic"
+                        : "Normal";
+    }
+    else if (move.name == "Techno Blast") {
+        move.type = attacker.item === "Burn Drive" ? "Fire"
+            : attacker.item === "Chill Drive" ? "Ice"
+                : attacker.item === "Douse Drive" ? "Water"
+                    : attacker.item === "Shock Drive" ? "Electric"
+                        : "Normal";
+    }
+    else if (move.name === "Multi-Attack" && attacker.item.indexOf("Memory") !== -1) {
+        move.type = getMemoryType(attacker.item);
+    }
+    else if (move.name === "Judgment" && attacker.item.indexOf("Plate") !== -1) {
+        move.type = getItemBoostType(attacker.item);
+    }
+    else if (move.name === "Revelation Dance") {
+        move.type = attacker.type1 !== 'Typeless' ? attacker.type1
+            : attacker.type2 !== 'Typeless' && attacker.type2 !== "" ? attacker.type2
+                : 'Typeless';
+    }
+    else if (move.name.includes(" Pledge") && move.name !== move.combinePledge) {
+        var bothPledgeNames = move.name + " " + move.combinePledge;
+        move.type = bothPledgeNames.includes("Grass") && bothPledgeNames.includes("Fire") ? 'Fire'
+            : bothPledgeNames.includes("Grass") && bothPledgeNames.includes("Water") ? 'Grass'
+                : bothPledgeNames.includes("Water") && bothPledgeNames.includes("Fire") ? 'Water'
+                    : 'Typeless';   //last case should never happen, just there to help with debugging
+    }
+}
+
+function ZMoves(move, field, attacker, isQuarteredByProtect, moveDescName) {
+    if (move.isSignatureZ) {
+        move.isZ = true;
+        if (field.isProtect) {
+            isQuarteredByProtect = true;
+        }
+    }
+    else if (move.isZ) {
+        var tempMove = move;
+
+        if (move.name.includes("Hidden Power") || move.name === 'Revelation Dance') {
+            move.type = "Normal";
+        }
+        else move.type = tempMove.type;
+
+        var ZName = ZMOVES_LOOKUP[tempMove.type];
+        var SigZ = getSignatureZMove(attacker.item, attacker.name, tempMove.name);
+        if (SigZ !== -1) ZName = SigZ;
+        //turning it into a generic single-target Z-move
+        move = moves[ZName];
+        if (move == undefined) move = tempMove;
+        move.name = ZName;
+        if (SigZ == -1) {
+            move.bp = tempMove.zp;
+            move.name = "Z-" + tempMove.name;
+            move.isZ = true;
+            move.category = tempMove.category;
+            moveDescName = ZName + " (" + move.bp + " BP)";
+        }
+        else
+            moveDescName = ZName;
+        move.isCrit = tempMove.isCrit;
+        move.hits = 1;
+        if (field.isProtect) {
+            isQuarteredByProtect = true;
+        }
+    }
+    return [move, isQuarteredByProtect, moveDescName];
+}
+
+function MaxMoves(move, attacker, isQuarteredByProtect, moveDescName, field) {
+    var exceptions_100_fight = ["Low Kick", "Reversal", "Final Gambit"];
+    var exceptions_80_fight = ["Double Kick", "Triple Kick"];
+    var exceptions_75_fight = ["Counter", "Seismic Toss"];
+    var exceptions_140 = ["Crush Grip", "Wring Out", "Magnitude", "Double Iron Bash", "Rising Voltage", "Triple Axel"];
+    var exceptions_130 = ["Pin Missile", "Power Trip", "Punishment", "Dragon Darts", "Dual Chop", "Electro Ball", "Heat Crash",
+        "Bullet Seed", "Grass Knot", "Bonemerang", "Bone Rush", "Fissure", "Icicle Spear", "Sheer Cold", "Weather Ball", "Tail Slap", "Guillotine", "Horn Drill",
+        "Flail", "Return", "Frustration", "Endeavor", "Natural Gift", "Trump Card", "Stored Power", "Rock Blast", "Gear Grind", "Gyro Ball", "Heavy Slam",
+        "Dual Wingbeat", "Terrain Pulse", "Surging Strikes", "Scale Shot"];
+    var exceptions_120 = ["Double Hit", "Spike Cannon"];
+    var exceptions_100 = ["Twineedle", "Beat Up", "Fling", "Dragon Rage", "Nature\'s Madness", "Night Shade", "Comet Punch", "Fury Swipes", "Sonic Boom", "Bide",
+        "Super Fang", "Present", "Spit Up", "Psywave", "Mirror Coat", "Metal Burst"];
+    var tempMove = move;
+    var maxName = MAXMOVES_LOOKUP[tempMove.type];
+    if (G_MAXMOVES_TYPE[attacker.name] == tempMove.type) {
+        maxName = G_MAXMOVES_LOOKUP[attacker.name];
+    }
+    move = moves[maxName];
+    move.type = tempMove.type;
+    if (move == undefined) move = tempMove; //prevents crashing when switching between Gen VII and VIII, only used for such a case
+    move.name = maxName;
+    if (['G-Max Drum Solo', 'G-Max Fireball', 'G-Max Hydrosnipe'].indexOf(maxName) == -1) {
+        if (move.type == "Fighting" || move.type == "Poison") {
+            if (tempMove.bp >= 150 || exceptions_100_fight.includes(tempMove.name)) move.bp = 100;
+            else if (tempMove.bp >= 110) move.bp = 95;
+            else if (tempMove.bp >= 75) move.bp = 90;
+            else if (tempMove.bp >= 65) move.bp = 85;
+            else if (tempMove.bp >= 55 || exceptions_80_fight.includes(tempMove.name)) move.bp = 80;
+            else if (tempMove.bp >= 45 || exceptions_75_fight.includes(tempMove.name)) move.bp = 75;
+            else move.bp = 70;
+        }
+        else {
+            if (tempMove.bp >= 150) move.bp = 150;
+            else if (tempMove.bp >= 110 || exceptions_140.includes(tempMove.name)) move.bp = 140;
+            else if (tempMove.bp >= 75 || exceptions_130.includes(tempMove.name)) move.bp = 130;
+            else if (tempMove.bp >= 65 || exceptions_120.includes(tempMove.name)) move.bp = 120;
+            else if (tempMove.bp >= 55 || exceptions_100.includes(tempMove.name)) move.bp = 110;
+            else if (tempMove.bp >= 45) move.bp = 100;
+            else move.bp = 90;
+        }
+    }
+    moveDescName = maxName + " (" + move.bp + " BP)";
+    if (tempMove.category == "Status") {
+        moveDescName = "Max Guard";
+        move.name = moveDescName;
+        move.bp = 0;
+        move.isCrit = false;
+    }
+    else if (tempMove.name == "(No Move)") {
+        moveDescName = "(No Move)";
+        move.bp = 0;
+        move.isCrit = false;
+    }
+    else move.isCrit = tempMove.isCrit;
+    move.category = tempMove.category;
+    move.hits = 1;
+    if (field.isProtect && ["G-Max One Blow", "G-Max Rapid Flow"].indexOf(maxName) == -1) isQuarteredByProtect = true;
+
+    return [move, isQuarteredByProtect, moveDescName];
+}
+
+function NaturePower(move, field, moveDescName) {         //Rename Nature Power to its appropriately called moves; needs to be done after Max Moves since Nature Power becomes Max Guard
+    move.category = "Special";
+    var natureZ = move.isZ;
+    var npMove = (field.terrain == "Electric") ? "Thunderbolt"
+        : (field.terrain == "Grassy") ? "Energy Ball"
+            : (field.terrain == "Psychic") ? "Psychic"
+                : (field.terrain == "Misty") ? "Moonblast"
+                    : "Tri Attack";
+    move.name = npMove;
+    move = moves[npMove];
+    move.isZ = natureZ;
+    move.hits = 1;
+    moveDescName = npMove;
+    return [move, moveDescName];
+}
+
+function statusMoves(move, attacker, defender, description) {
+    if (move.name === "Pain Split") {
+        return { "damage": [Math.floor((defender.curHP - attacker.curHP) / 2)], "description": buildDescriptionSS(description) };
+    }
+    else if (move.bp === 0 || move.category === "Status") {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+}
+
+function abilityIgnore(attacker, move, defAbility, description) {
+    if (defAbility != "Shadow Shield" && defAbility != "Full Metal Body" && defAbility != "Prism Armor") {
+        if (["Mold Breaker", "Teravolt", "Turboblaze"].indexOf(attacker.ability) !== -1) {
+            defAbility = "";
+            description.attackerAbility = attacker.ability;
+        }
+        else if (["Moongeist Beam", "Sunsteel Strike", "Photon Geyser", "Searing Sunraze Smash", "Menacing Moonraze Maelstrom",
+            "Light That Burns the Sky", 'G-Max Drum Solo', 'G-Max Fireball', 'G-Max Hydrosnipe'].indexOf(move.name) !== -1)
+            defAbility = ""; //works as a mold breaker
+    }
+
+    return [defAbility, description];
+}
+
+function critMove(move, defAbility) {
+    return move.isCrit && ["Battle Armor", "Shell Armor"].indexOf(defAbility) === -1;
+}
+
+
+function NaturalGift(move, attacker, description) {
+        var gift = getNaturalGift(attacker.item);
+        move.type = gift.t;
+        move.bp = gift.p;
+        description.attackerItem = attacker.item;
+        description.moveBP = move.bp;
+        description.moveType = move.type;
+    
+    return [move, description];
+}
+
+function AuraWheel(move, attacker) {
+    return (attacker.name == "Morpeko-Hangry") ? "Dark" : move.type;
+}
+
+function ateIzeTypeChange(move, attacker, description) {
+    var isBoosted = false;
+    if (attacker.ability === "Liquid Voice" && move.isSound) {
+        move.type = "Water";
+        description.attackerAbility = attacker.ability;
+    }
+    else {
+        if (attacker.ability !== "Normalize" && move.type === "Normal") { //Z-Moves don't receive -ate type changes
+            switch (attacker.ability) {
+                case "Aerilate":
+                    move.type = "Flying";
+                    break;
+                case "Pixilate":
+                    move.type = "Fairy";
+                    break;
+                case "Refrigerate":
+                    move.type = "Ice";
+                    break;
+                default:    //Galvanize
+                    move.type = "Electric";
+            }
+            if (attacker.isDynamax)
+                description.moveName = MAXMOVES_LOOKUP[move.type] + " (" + move.bp + " BP)";
+            isBoosted = true;     //indicates whether the move gets the boost or not
+        }
+        else if(attacker.ability === "Normalize") {  //Normalize
+            move.type = "Normal";
+            if (attacker.isDynamax)
+                description.moveName = "Max Strike (" + move.bp + " BP)";
+            isBoosted = true;     //indicates whether the move gets the boost or not
+        }
+    }
+
+    return [move, description, isBoosted];
+}
+
+function immunityChecks(move, attacker, defender, field, description, defAbility, typeEffectiveness) {
+    if (typeEffectiveness === 0) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if ((defAbility === "Wonder Guard" && typeEffectiveness <= 1) ||
+        (move.type === "Grass" && defAbility === "Sap Sipper") ||
+        (move.type === "Fire" && defAbility.indexOf("Flash Fire") !== -1) ||
+        (move.type === "Water" && ["Dry Skin", "Storm Drain", "Water Absorb"].indexOf(defAbility) !== -1) ||
+        (move.type === "Electric" && ["Lightning Rod", "Motor Drive", "Volt Absorb"].indexOf(defAbility) !== -1) ||
+        (move.type === "Ground" && !field.isGravity && defAbility === "Levitate") ||
+        (move.isBullet && defAbility === "Bulletproof") ||
+        (move.isSound && defAbility === "Soundproof")) {
+        description.defenderAbility = defAbility;
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (move.type === "Ground" && !field.isGravity && defender.item === "Air Balloon" && move.name !== "Thousand Arrows") {
+        description.defenderItem = defender.item;
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if ((field.weather === "Harsh Sun" && move.type === "Water") || (field.weather === "Heavy Rain" && move.type === "Fire")) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Sky Drop" &&
+        ([defender.type1, defender.type2].indexOf("Flying") !== -1 ||
+            (gen >= 6 && defender.weight >= 200.0) || field.isGravity)) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Synchronoise" &&
+        [defender.type1, defender.type2].indexOf(attacker.type1) === -1 && [defender.type1, defender.type2].indexOf(attacker.type2) === -1) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (defender.isDynamax && ["Grass Knot", "Low Kick", "Heat Crash", "Heavy Slam"].indexOf(move.name) !== -1) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if ((defAbility === "Damp" || attacker.ability === "Damp") && ["Self-Destruct", "Explosion", "Mind Blown", "Misty Explosion"].indexOf(move.name) !== -1) {
+        description.defenderAbility = defAbility;
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Fling" && cantFlingItem(attacker.item, attacker.name, defAbility)) {
+        description.attackerItem = attacker.item;
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Natural Gift" && attacker.item.indexOf(" Berry") === -1) {
+        return { "damage": [0], "description": buildDescriptionSS(description) };
+    }
+
+    return -1;
+}
+
+//Special Cases
+function setDamage(move, attacker, defender, description, isQuarteredByProtect) {
+    var isParentBond = attacker.ability === "Parental Bond";
+    //a. Counterattacks (Counter, Mirror Coat, Metal Burst, Bide)
+
+    //b. Defender HP Dependent (Super Fang/Nature's Madness, Guardian of Alola)
+    var def_curHP;
+    if (move.name === "Super Fang" || move.name === "Nature\'s Madness") {
+        def_curHP = Math.floor(defender.curHP / 2);
+        if (isParentBond) {
+            def_curHP = Math.floor(def_curHP * 3 / 2);
+        }
+        if (defender.isDynamax) {
+            def_curHP = Math.floor(def_curHP / 2);
+        }
+        return { "damage": [def_curHP], "description": buildDescriptionSS(description) };
+    }
+    else if (move.name === "Guardian of Alola") {
+        if (!isQuarteredByProtect) {
+            def_curHP = Math.floor(defender.curHP * 3 / 4);
+        }
+        else {
+            def_curHP = Math.floor(defender.curHP * 3 / 16);
+        }
+        return { "damage": [def_curHP], "description": buildDescriptionSS(description) };
+    }
+
+    //c. Attacker HP Dependent (Endeavor, Final Gambit)
+    if (move.name === "Endeavor") {
+        var endvr_dmg = 0;
+        if (attacker.curHP < defender.curHP) endvr_dmg = defender.curHP - attacker.curHP;
+        return { "damage": [endvr_dmg], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Final Gambit") {
+        var at_curHP = attacker.curHP;
+        return { "damage": [at_curHP], "description": buildDescriptionSS(description) };
+    }
+
+    //d. Set Damage (Sonic Boom, Dragon Rage)
+    if (move.name === "Sonic Boom") {
+        return !isParentBond
+            ? { "damage": [20], "description": buildDescriptionSS(description) }
+            : { "damage": [40], "description": buildDescriptionSS(description) };
+    }
+    if (move.name === "Dragon Rage") {
+        return !isParentBond
+            ? { "damage": [40], "description": buildDescriptionSS(description) }
+            : { "damage": [80], "description": buildDescriptionSS(description) };
+    }
+
+    //e. Level Dependent Damage (Seismic Toss, Night Shade)
+    if (move.name === "Seismic Toss" || move.name === "Night Shade") {
+        var lv = attacker.level;
+        if (isParentBond) {
+            lv *= 2;
+        }
+        return { "damage": [lv], "description": buildDescriptionSS(description) };
+    }
+
+    //f. OHKO moves
+
+    //g. Psywave
+
+    return -1;
+}
+
+function pIsGrounded(mon, field) {
+    return (mon.item == "Iron Ball" || field.isGravity || (mon.type1 !== "Flying" && mon.type2 !== "Flying" &&
+        mon.item !== "Air Balloon" && mon.ability !== "Levitate"));
+}
+
+//1. Custom BP
+function basePowerFunc(move, description, turnOrder, attacker, defender, field, attIsGrounded, defIsGrounded, defAbility) {
+    var basePower;
+    switch (move.name) {
+        //a. Speed based
+        //a.i. Gyro Ball
+        case "Gyro Ball":
+            basePower = Math.min(150, Math.floor(25 * defender.stats[SP] / attacker.stats[SP]));
+            description.moveBP = basePower;
+            break;
+        //a.ii. Electro Ball
+        case "Electro Ball":
+            var r = (defender.stats[SP] == 0) ? 0 : Math.floor(attacker.stats[SP] / defender.stats[SP]);
+            basePower = r >= 4 ? 150 : r >= 3 ? 120 : r >= 2 ? 80 : r >= 1 ? 60 : 40;
+            description.moveBP = basePower;
+            break;
+
+        //b. Weight based
+        //b.i. Low Kick, Grass Knot
+        case "Low Kick":
+        case "Grass Knot":
+            var w = defender.weight;
+            basePower = w >= 200 ? 120 : w >= 100 ? 100 : w >= 50 ? 80 : w >= 25 ? 60 : w >= 10 ? 40 : 20;
+            description.moveBP = basePower;
+            if (defAbility == "Heavy Metal" || defAbility == "Light Metal")
+                description.defenderAbility = defAbility;
+            if (defender.item == "Float Stone")
+                description.defenderItem = defender.item;
+            break;
+        //b.ii. Heavy Slam, Heat Crash
+        case "Heavy Slam":
+        case "Heat Crash":
+            var wr = attacker.weight / defender.weight;
+            basePower = wr >= 5 ? 120 : wr >= 4 ? 100 : wr >= 3 ? 80 : wr >= 2 ? 60 : 40;
+            description.moveBP = basePower;
+            if (defAbility == "Heavy Metal" || defAbility == "Light Metal")
+                description.defenderAbility = defAbility;
+            if (defender.item == "Float Stone")
+                description.defenderItem = defender.item;
+            if (attacker.ability == "Heavy Metal" || attacker.ability == "Light Metal")
+                description.attackerAbility = attacker.ability;
+            if (attacker.item == "Float Stone")
+                description.attackerItem = attacker.item;
+            break;
+
+        //c. HP based
+        //c.i. Eruption, Water Spout, Dragon Energy
+        case "Eruption":
+        case "Water Spout":
+        case "Dragon Energy":
+            basePower = Math.max(1, Math.floor(150 * attacker.curHP / attacker.maxHP));
+            description.moveBP = basePower;
+            break;
+        //c.ii. Flail, Reversal
+        case "Flail":
+        case "Reversal":
+            var p = Math.floor(48 * attacker.curHP / attacker.maxHP);
+            basePower = p <= 1 ? 200 : p <= 4 ? 150 : p <= 9 ? 100 : p <= 16 ? 80 : p <= 32 ? 40 : 20;
+            description.moveBP = basePower;
+            break;
+        //c.iii. Crush Grip, Wring Out
+        case "Crush Grip":
+        case "Wring Out":
+            basePower = floor(pokeRound(120 * 100 * floor(attacker.curHP * 0x1000 / attacker.maxHP) / 0x1000) / 100);
+            description.moveBP = basePower;
+            break;
+
+        //d. Friendship based   (not done under the assumption that it will always deal max damage)
+        //d.i. Return
+        //d.ii. Frustration
+
+        //e. Counter based
+        //e.i. Fury Cutter
+        //e.ii. Rollout, Ice Ball
+        //e.iii. Spit Up
+
+        //f. Boost based
+        //f.i. Stored Power, Power Trip
+        case "Stored Power":
+        case "Power Trip":
+            basePower = 20 + 20 * countBoosts(attacker.boosts);
+            description.moveBP = basePower;
+            break;
+        //f.ii. Punishment
+        case "Punishment":
+            basePower = Math.min(200, 60 + 20 * countBoosts(defender.boosts));
+            description.moveBP = basePower;
+            break;
+
+        //g. Dichotomous BP
+        //g.i. Acrobatics
+        case "Acrobatics":
+            basePower = attacker.item === "Flying Gem" || attacker.item === "" ? 110 : 55;
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.ii. Hex
+        case "Hex":
+            basePower = move.bp * (defender.status !== "Healthy" ? 2 : 1);
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.iii. Smelling Salts
+        case "Smelling Salts":
+            basePower = move.bp * (defender.status === "Paralyzed" ? 2 : 1);
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.iv. Wake-Up Slap
+        case "Wake-Up Slap":
+            basePower = move.bp * (defender.status === "Asleep" ? 2 : 1);
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.v. Weather Ball
+        case "Weather Ball":
+            basePower = ["", "Strong Winds"].indexOf(field.weather) === -1 ? 100 : 50;
+            if (basePower !== move.bp) {
+                description.moveBP = basePower;
+                description.weather = field.weather;
+                description.moveType = move.type;
+            }
+            break;
+        //g.vi. Water Shuriken
+        case "Water Shuriken":
+            basePower = (attacker.name === "Ash-Greninja" && attacker.ability === "Battle Bond") ? 20 : 15;
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.vii. Terrain Pulse
+        case "Terrain Pulse":
+            basePower = (field.terrain !== "" && attIsGrounded) ? move.bp * 2 : move.bp;
+            if (basePower !== move.bp) {
+                description.moveBP = basePower;
+                description.terrain = field.terrain;
+                description.moveType = move.type;
+            }
+            break;
+        //g.viii. Rising Voltage
+        case "Rising Voltage":
+            basePower = (field.terrain === "Electric" && defIsGrounded) ? move.bp * 2 : move.bp;
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.ix. Grass Pledge, Fire Pledge, Water Pledge combined
+        case "Grass Pledge":
+        case "Fire Pledge":
+        case "Water Pledge":
+            basePower = move.combinePledge !== move.name ? 150 : move.bp;
+            description.moveBP = basePower;
+            if (move.combinePledge !== move.name)
+                description.moveType = move.type;
+            break;
+        //g.x. Payback, Fisheous Rend, Bolt Beak                                            CONSIDER ISDOUBLE
+        case "Payback":
+            basePower = turnOrder === "LAST" ? 100 : 50;
+            if (basePower !== move.bp) description.moveBP = basePower;
+            break;
+        //g.xi. Everything else (Assurance, Avalanche, Revenge, Gust, Twister, Pursuit, Round, Stomping Tantrum)    CHECK DEFAULT; CURRENTLY ALSO HAS FISHEOUS REND AND BOLT BEAK
+
+        //h. Item based
+        //h.i. Fling
+        case "Fling":
+            basePower = getFlingPower(attacker.item);
+            description.moveBP = basePower;
+            description.attackerItem = attacker.item;
+            break;
+        //h.ii. Natural Gift
+        case "Natural Gift":
+            if (attacker.item.indexOf(" Berry") !== -1)
+                [move, description] = NaturalGift(move, attacker, description);
+            break;
+
+        //i. Other
+        //i.i. Beat Up
+        //i.ii. Echoed Voice
+        //i.iii. Hidden Power (I think it's for pre Gen VI?)
+        //i.iv. Magnitude
+        //i.v. Present
+        //i.vi. Triple Kick, Triple Axel 
+        case "Triple Kick":
+        case "Triple Axel":
+            if (move.tripleHit3)
+                basePower = move.bp * 3;
+            else if (move.tripleHit2)
+                basePower = move.bp * 2;
+            else
+                basePower = move.bp;
+            break;
+        //i.vii. Trump Card
+
+        default:
+            if (move.isDouble && ['Retaliate', 'Fusion Bolt', 'Fusion Flare', 'Lash Out'].indexOf(move.name) === -1) {
+                basePower = 2 * move.bp;
+                if (basePower !== move.bp) description.moveBP = basePower;
+            }
+            else basePower = move.bp;
+    }
+
+    return [basePower, description];
+}
+
+//2. BP Mods
+function calcBPMods(attacker, defender, field, move, description, ateIzeBoosted, basePower, attIsGrounded, defIsGrounded, turnOrder, defAbility) {
+    var bpMods = [];
+    var isAttackerAura = (attacker.ability === (move.type + " Aura"));
+    var isDefenderAura = defAbility === (move.type + " Aura");
+    var auraActive = ($("input:checkbox[id='" + move.type.toLowerCase() + "-aura']:checked").val() != undefined);
+    var auraBreak = ($("input:checkbox[id='aura-break']:checked").val() != undefined);
+
+    //a. Aura Break
+    if (auraActive && auraBreak && !field.isNeutralizingGas) {
+        bpMods.push(0x0C00);
+        if (isAttackerAura || attacker.ability == "Aura Break") {
+            description.attackerAbility = attacker.ability;
+        }
+        else if (isDefenderAura || defAbility == "Aura Break") {
+            description.defenderAbility = defAbility;
+        }
+    }
+    //b. Rivalry
+
+    //c. 1.2x Abilities
+    //c.i. Galvanize, Aerilate, Pixilate, Refrigerate, Normalize        (Technically Normalize is separate but it doesn't hurt to handle it where it is now)
+    if (!move.isZ && !attacker.isDynamax && ateIzeBoosted) {     //function ateIzeTypeChange sets this value
+        var ateIzeMultiplier = gen > 6 ? 0x1333 : 0x14CD;
+        bpMods.push(ateIzeMultiplier);
+        description.attackerAbility = attacker.ability;
+    }
+    //c.ii Reckless, Iron Fist                                          (Same deal)
+    else if ((attacker.ability === "Reckless" && move.hasRecoil) || (attacker.ability === "Iron Fist" && move.isPunch)) {
+        bpMods.push(0x1333);
+        description.attackerAbility = attacker.ability;
+    }
+
+    //d. Field Abilities
+    //d.i. Battery
+    if (field.isBattery && move.category === "Special") {
+        bpMods.push(0x14CD);
+        description.isBattery = true;
+    }
+    //d.ii. Power Spot
+    if (field.isPowerSpot) {
+        bpMods.push(0x14CD);
+        description.isPowerSpot = true;
+    }
+    //d.iii. Ally Steely Spirit (probably doesn't go here but Smogon makes Doubles research a pain to find)
+    if (field.isSteelySpirit && move.type === "Steel") {
+        bpMods.push(0x1800);
+        description.isSteelySpirit = true;
+    }
+
+    //e. 1.3x Abilities
+    //e.i. Sheer Force
+    if (attacker.ability === "Sheer Force" && move.hasSecondaryEffect) {
+        bpMods.push(0x14CD);
+        description.attackerAbility = attacker.ability;
+    }
+    //e.ii. Sand Force
+    else if (attacker.ability === "Sand Force" && field.weather === "Sand" && ["Rock", "Ground", "Steel"].indexOf(move.type) !== -1) {
+        bpMods.push(0x14CD);
+        description.attackerAbility = attacker.ability;
+        description.weather = field.weather;
+    }
+    //e.iii. Analytic
+    else if (attacker.ability === "Analytic" && turnOrder !== "FIRST") {
+        bpMods.push(0x14CD);
+        description.attackerAbility = attacker.ability;
+    }
+    //e.iv. Tough Claws
+    else if (attacker.ability === "Tough Claws" && move.makesContact) {
+        bpMods.push(0x14CD);
+        description.attackerAbility = attacker.ability;
+    }
+    //e.v. Punk Rock
+    else if (attacker.ability == "Punk Rock" && move.isSound) {
+        bpMods.push(0x14CD);
+        description.attackerAbility = attacker.ability;
+    }
+
+    //f. Fairy Aura, Dark Aura
+    if (auraActive && !auraBreak && !field.isNeutralizingGas) {
+        bpMods.push(0x1548);
+        if (isAttackerAura) {
+            description.attackerAbility = attacker.ability;
+        }
+        else if (isDefenderAura) {
+            description.defenderAbility = defAbility;
+        }
+    }
+
+    //If the BP before this point would trigger Technician, don't apply it
+    var tempBP = pokeRound(basePower * chainMods(bpMods) / 0x1000);
+
+    //g. 1.5x Abilities (Technician, Flare Boost, Toxic Boost, Strong Jaw, Mega Launcher, Steely Spirit)
+    if ((attacker.ability === "Technician" && tempBP <= 60) ||
+        (attacker.ability === "Flare Boost" && attacker.status === "Burned" && move.category === "Special") ||
+        (attacker.ability === "Toxic Boost" && (attacker.status === "Poisoned" || attacker.status === "Badly Poisoned") && move.category === "Physical") ||
+        (attacker.ability === "Mega Launcher" && move.isPulse) ||
+        (attacker.ability === "Strong Jaw" && move.isBite) ||
+        (attacker.ability === "Steely Spirit" && move.type === "Steel")) {
+        bpMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+    }
+
+    //h. Heatproof
+    if (defAbility === "Heatproof" && move.type === "Fire") {
+        bpMods.push(0x800);
+        description.defenderAbility = defAbility;
+    }
+
+    //i. Dry Skin
+    else if (defAbility === "Dry Skin" && move.type === "Fire") {
+        bpMods.push(0x1400);
+        description.defenderAbility = defAbility;
+    }
+
+    //j. 1.1x Items
+    if ((attacker.item === "Muscle Band" && move.category === "Physical") ||
+        (attacker.item === "Wise Glasses" && move.category === "Special")) {
+        bpMods.push(0x1199);
+        description.attackerItem = attacker.item;
+    }
+
+    //k. 1.2x Items
+    else if (getItemBoostType(attacker.item) === move.type) {
+        var itemTypeMultiplier = gen > 3 ? 0x1333 : 0x1199;
+        bpMods.push(itemTypeMultiplier);
+        description.attackerItem = attacker.item;
+    }
+    else if (getItemDualTypeBoost(attacker.item, attacker.name).includes(move.type)) {
+        bpMods.push(0x1333);
+        description.attackerItem = attacker.item;
+    }
+
+    //l. Gems
+    else if (attacker.item === move.type + " Gem") {
+        var gemMultiplier = gen > 5 ? 0x14CD : 0x1800;
+        bpMods.push(gemMultiplier);
+        description.attackerItem = attacker.item;
+    }
+
+    //m. Solar Beam, Solar Blade
+    if ((move.name === "Solar Beam" || move.name === "SolarBeam" || move.name === "Solar Blade") && ["None", "Sun", "Harsh Sun", "Strong Winds", ""].indexOf(field.weather) === -1 && attacker.item !== 'Utility Umbrella') {
+        bpMods.push(0x800);
+        description.moveBP = move.bp / 2;
+        description.weather = field.weather;
+    }
+
+    //n. Me First
+
+    //o. Knock Off
+    else if (gen > 5 && move.name === "Knock Off" && defender.name !== null && !cantRemoveItem(defender.item, defender.name, field.terrain)) {
+        bpMods.push(0x1800);
+        description.moveBP = move.bp * 1.5;
+    }//p. Misty Explosion
+    else if ((move.name === "Misty Explosion" && field.terrain == "Misty" && attIsGrounded) ||
+        (move.name === "Grav Apple" && field.isGravity)) {
+        bpMods.push(0x1800);
+        description.moveBP = move.bp * 1.5;
+    }//q. Expanding Force
+    else if (move.name === "Expanding Force" && field.terrain == "Psychic" && attIsGrounded) {
+        move.isSpread = true;
+        bpMods.push(0x1800);
+        description.moveBP = move.bp * 1.5;
+    }
+
+    //r. Helping Hand
+    if (field.isHelpingHand) {  //calculated differently in gen 3
+        bpMods.push(0x1800);
+        description.isHelpingHand = true;
+    }
+
+    //s. Charge, Electromorphosis
+    if (attacker.ability === "Electromorphosis" && attacker.abilityOn && move.type === "Electric") {
+        bpMods.push(0x2000);
+        description.attackerAbility = attacker.ability;
+    }
+
+    //t. Double power (Facade, Brine, Venoshock, Retaliate, Fusion Bolt, Fusion Flare, Lash Out)
+    if ((move.name === "Facade" && ["Burned", "Paralyzed", "Poisoned", "Badly Poisoned"].indexOf(attacker.status) !== -1) ||
+        (move.name === "Brine" && defender.curHP <= defender.maxHP / 2) ||
+        (move.name === "Venoshock" && (defender.status === "Poisoned" || defender.status === "Badly Poisoned")) ||
+        (['Retaliate', 'Fusion Bolt', 'Fusion Flare', 'Lash Out'].indexOf(move.name) !== -1 && move.isDouble)) {
+        bpMods.push(0x2000);
+        description.moveBP = move.bp * 2;
+    }
+
+    //u. Offensive Terrain
+    if (attIsGrounded) {
+        var terrainMultiplier = gen > 7 ? 0x14CD : 0x1800;
+        if (field.terrain === "Electric" && move.type === "Electric") {
+            bpMods.push(terrainMultiplier);
+            description.terrain = field.terrain;
+        } else if (field.terrain === "Grassy" && move.type == "Grass") {
+            bpMods.push(terrainMultiplier);
+            description.terrain = field.terrain;
+        } else if (field.terrain === "Psychic" && move.type == "Psychic") {
+            bpMods.push(terrainMultiplier);
+            description.terrain = field.terrain;
+        }
+    }//v. Defensive Terrain
+    if (defIsGrounded) {
+        if ((field.terrain === "Misty" && move.type === "Dragon") ||
+            (field.terrain === "Grassy" && (move.name === "Earthquake" || move.name === "Bulldoze"))) {
+            bpMods.push(0x800);
+            description.terrain = field.terrain;
+        }
+    }
+
+    //w. Mud Sport, Water Sport
+    return [bpMods, description, move];
+}
+
+//3. Attack
+function calcAttack(move, attacker, defender, description, necrozmaMove, smartMove, isCritical, defAbility) {
+    //a. Foul Play, Photon Geyser, Light That Burns The Sky, Shell Side Arm, Body Press
+    var attack;
+    var attackSource = move.name === "Foul Play" ? defender : attacker;
+    var usesPhysicalAttackStat = move.category === "Physical" || (necrozmaMove && attacker.stats[AT] >= attacker.stats[SA]) || (smartMove && (attacker.stats[AT] / defender.stats[DF]) >= (attacker.stats[SA] / defender.stats[SD]));
+    var usesDefenseStat = move.name === "Body Press";
+    var attackStat = usesDefenseStat ? DF : usesPhysicalAttackStat ? AT : SA;
+    description.attackEVs = attacker.evs[attackStat] +
+        (NATURES[attacker.nature][0] === attackStat ? "+" : NATURES[attacker.nature][1] === attackStat ? "-" : "") + " " +
+        toSmogonStat(attackStat);
+    //b. Unaware
+    if (defAbility === "Unaware") {
+        attack = attackSource.rawStats[attackStat];
+        description.defenderAbility = defAbility;
+    }
+    //Spectral Thief and Meteor Beam aren't part of the calculations but are instead here to properly account for the boosts they give
+    else if (move.name === "Spectral Thief" && defender.boosts[attackStat] > 0) {
+        description.attackBoost = Math.min(6, attacker.boosts[attackStat] + defender.boosts[attackStat]);
+        attack = getModifiedStat(attackSource.rawStats[attackStat], Math.min(6, attacker.boosts[attackStat] + defender.boosts[attackStat]));
+    }
+    else if (move.name === "Meteor Beam") {
+        description.attackBoost = Math.min(6, attackSource.boosts[attackStat] + 1);
+        attack = getModifiedStat(attackSource.rawStats[attackStat], Math.min(6, attackSource.boosts[attackStat] + 1));
+    } //c. Crit
+    else if (attackSource.boosts[attackStat] === 0 || (isCritical && attackSource.boosts[attackStat] < 0)) {
+        attack = attackSource.rawStats[attackStat];
+    } //d. Attack boosts and drops
+    else {
+        attack = attackSource.stats[attackStat];
+        description.attackBoost = attackSource.boosts[attackStat];
+    }
+
+    //e. Hustle
+    // unlike all other attack modifiers, Hustle gets applied directly
+    if (attacker.ability === "Hustle" && move.category === "Physical") {
+        attack = pokeRound(attack * 3 / 2);
+        description.attackerAbility = attacker.ability;
+    }
+
+    return [attack, description];
+}
+
+//4. Attack Mods
+function calcAtMods(move, attacker, defAbility, description, field) {
+    atMods = [];
+
+    //a. 0.5x Abilities
+    //Slow Start also halves damage with special Z-moves
+    if ((attacker.ability === "Slow Start" && attacker.abilityOn && (move.category === "Physical" || (move.category === "Special" && move.isZ))) ||
+        (attacker.ability === "Defeatist" && attacker.curHP <= attacker.maxHP / 2)) {
+        atMods.push(0x800);
+        description.attackerAbility = attacker.ability;
+    }
+    //b. Flower Gift
+    if (attacker.ability === "Flower Gift" && attacker.name ==="Cherrim" && field.weather.indexOf("Sun") > -1 && move.category === "Physical" && attacker.item !== 'Utility Umbrella') {
+        atMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+        description.weather = field.weather;
+    }
+    else if (field.isFlowerGiftAtk && field.weather.indexOf("Sun") > -1 && move.category === "Physical" && attacker.item !== 'Utility Umbrella') {
+        atMods.push(0x1800);
+        description.isFlowerGiftAtk = true;
+        description.weather = field.weather;
+    }
+    //c. 1.5x Offensive Abilities
+    if ((attacker.ability === "Guts" && attacker.status !== "Healthy" && move.category === "Physical") ||
+        (attacker.ability === "Overgrow" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Grass") ||
+        (attacker.ability === "Blaze" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Fire") ||
+        (attacker.ability === "Torrent" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Water") ||
+        (attacker.ability === "Swarm" && attacker.curHP <= attacker.maxHP / 3 && move.type === "Bug") ||
+        (attacker.ability === "Transistor" && move.type === "Electric") ||
+        (attacker.ability === "Dragon\'s Maw" && move.type === "Dragon")) {     //Overgrow/Blaze/Torrent/Swarm work differently in gen 3
+        atMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+    } else if (attacker.ability === "Flash Fire" && attacker.abilityOn && move.type === "Fire") {   //Flash Fire works differently in gen 3
+        atMods.push(0x1800);
+        description.attackerAbility = "Flash Fire";
+    } else if ((attacker.ability === "Steelworker") && move.type === "Steel") {
+        atMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+    } else if (attacker.ability === "Solar Power" && field.weather.indexOf("Sun") > -1 && move.category === "Special" && attacker.item !== 'Utility Umbrella') {
+        atMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+        description.weather = field.weather;
+    } else if (attacker.ability === "Gorilla Tactics" && move.category === "Physical" && !attacker.isDynamax) {
+        atMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+    }else if (["Plus", "Minus"].indexOf(attacker.ability) !== -1 && attacker.abilityOn){
+    atMods.push(0x1800);
+    description.attackerAbility = attacker.ability;
+    }
+
+    //d. 2.0x Offensive Abilities
+    //Add Stakeout here as well
+    if ((attacker.ability === "Water Bubble" && move.type === "Water") ||
+        ((attacker.ability === "Huge Power" || attacker.ability === "Pure Power") && move.category === "Physical")) {
+        atMods.push(0x2000);
+        description.attackerAbility = attacker.ability;
+    }
+    //e. 0.5x Defensive Abilities
+    if ((defAbility === "Thick Fat" && (move.type === "Fire" || move.type === "Ice")) || (defAbility === "Water Bubble" && move.type === "Fire")) {
+        atMods.push(0x800);
+        description.defenderAbility = defAbility;
+    }
+    //f. 2.0x Items
+    if ((attacker.item === "Thick Club" && (attacker.name === "Cubone" || attacker.name === "Marowak" || attacker.name === "Marowak-Alola") && move.category === "Physical") ||
+        (attacker.item === "Deep Sea Tooth" && attacker.name === "Clamperl" && move.category === "Special") ||
+        (attacker.item === "Light Ball" && (attacker.name === "Pikachu" || attacker.name === "Pikachu-Gmax"))) {
+        atMods.push(0x2000);
+        description.attackerItem = attacker.item;
+    } //g. 1.5x Items
+    else if ((attacker.item === "Choice Band" && move.category === "Physical" && !attacker.isDynamax) ||
+        (attacker.item === "Choice Specs" && move.category === "Special" && !attacker.isDynamax)) {
+        atMods.push(0x1800);
+        description.attackerItem = attacker.item;
+    }
+    return [atMods, description];
+}
+
+//5. Defense
+function calcDefense(move, attacker, defender, description, hitsPhysical, isCritical, field) {
+    //a. Psyshock, Psystrike, Secret Sword (handled in hitsPhysical declaration)
+    var defenseStat = hitsPhysical ? DF : SD;
+    description.defenseEVs = defender.evs[defenseStat] +
+        (NATURES[defender.nature][0] === defenseStat ? "+" : NATURES[defender.nature][1] === defenseStat ? "-" : "") + " " +
+        toSmogonStat(defenseStat);
+    //b. Wonder Room
+
+    //Spectral Thief isn't part of the calculations but is instead here to properly account for the boosts it takes
+    if (move.name === "Spectral Thief" && defender.boosts[defenseStat] > 0) {
+        defense = defender.rawStats[defenseStat];
+    }//c. Chip Away, Sacred Sword; d. Crits
+    else if (defender.boosts[defenseStat] === 0 || (isCritical && defender.boosts[defenseStat] > 0) || move.ignoresDefenseBoosts) {
+        defense = defender.rawStats[defenseStat];
+    }//e. Unaware
+    else if (attacker.ability === "Unaware") {
+        defense = defender.rawStats[defenseStat];
+        description.attackerAbility = attacker.ability;
+    }//f. Defense drops and boosts
+    else {
+        defense = defender.stats[defenseStat];
+        description.defenseBoost = defender.boosts[defenseStat];
+    }
+
+    //g. Sandstorm Rock types
+    // unlike all other defense modifiers, Sandstorm SpD boost gets applied directly
+    if (field.weather === "Sand" && gen > 3 && (defender.type1 === "Rock" || defender.type2 === "Rock") && !hitsPhysical) {
+        defense = pokeRound(defense * 3 / 2);
+        description.weather = field.weather;
+    }
+    return [defense, description];
+}
+
+//6. Defense Mods
+function calcDefMods(move, defender, field, description, hitsPhysical, defAbility) {
+    var dfMods = [];
+    //a. Flower Gift
+    if (defAbility === "Flower Gift" && defender.name === "Cherrim" && field.weather.indexOf("Sun") > -1 && !hitsPhysical && defender.item !== 'Utility Umbrella') {
+        dfMods.push(0x1800);
+        description.defenderAbility = defAbility;
+        description.weather = field.weather;
+    }
+    else if (field.isFlowerGiftSpD && field.weather.indexOf("Sun") > -1 && !hitsPhysical && defender.item !== 'Utility Umbrella') {
+        dfMods.push(0x1800);
+        description.isFlowerGiftSpD = true;
+        description.weather = field.weather;
+    }
+    //b. 1.5x Abilities
+    if ((defAbility === "Marvel Scale" && defender.status !== "Healthy" && hitsPhysical) ||
+        (defAbility === "Grass Pelt" && field.terrain === "Grassy" && hitsPhysical)) {
+        dfMods.push(0x1800);
+        description.defenderAbility = defAbility;
+    } //c. 2x Abilities
+    else if ((defAbility === "Fur Coat" && hitsPhysical) ||
+        (defAbility === "Ice Scales" && ((!hitsPhysical && !move.makesContact) || move.dealsPhysicalDamage))) {
+        dfMods.push(0x2000);
+        description.defenderAbility = defAbility;
+    }
+    //d. 1.5x Items
+    if ((defender.item === "Assault Vest" && !hitsPhysical) ||
+        (defender.item === "Eviolite" && defender.canEvolve)) {
+        dfMods.push(0x1800);
+        description.defenderItem = defender.item;
+    } //e. 2.0x Items
+    else if ((defender.item === "Deep Sea Scale" && defender.name === "Clamperl" && !hitsPhysical) ||
+        (defender.item === "Metal Powder" && defender.name === "Ditto")) {
+        dfMods.push(0x2000);
+        description.defenderItem = defender.item;
+    }
+    return [dfMods, description];
+}
+
+//7. Base Damage
+function calcBaseDamage(attacker, basePower, attack, defense) {
+    return Math.floor(Math.floor((Math.floor((2 * attacker.level) / 5 + 2) * basePower * attack) / defense) / 50 + 2);
+}
+
+//8. General Damage Mods
+function calcGeneralMods(baseDamage, move, attacker, defender, defAbility, field, description, isCritical, typeEffectiveness, isQuarteredByProtect) {
+    //a. Spread Move mod
+    if (field.format !== "Singles" && move.isSpread) {
+        baseDamage = pokeRound(baseDamage * 0xC00 / 0x1000);
+    }
+    //b. Parental Bond mod
+    baseDamage = attacker.isChild ? pokeRound(baseDamage * 0x0400 / 0x1000) : baseDamage;    //should be accurate based on implementation
+    //c. Weather mod
+    if (((field.weather.indexOf("Sun") > -1 && move.type === "Fire") || (field.weather.indexOf("Rain") > -1 && move.type === "Water")) && defender.item !== 'Utility Umbrella') {
+        baseDamage = pokeRound(baseDamage * 0x1800 / 0x1000);
+        description.weather = field.weather;
+    } else if ((field.weather === "Strong Winds" && (defender.type1 === "Flying" || defender.type2 === "Flying") &&
+        typeChart[move.type]["Flying"] > 1)) {
+        description.weather = field.weather;        //not actually a mod, just adding the description here
+    } else if ((((field.weather === "Sun" && move.type === "Water") || (field.weather === "Rain" && move.type === "Fire")) && defender.item !== 'Utility Umbrella')) {
+        baseDamage = pokeRound(baseDamage * 0x800 / 0x1000);
+        description.weather = field.weather;
+    }
+    //d. Crit mod
+    if (isCritical) {
+        baseDamage = Math.floor(baseDamage * 1.5);
+        description.isCritical = isCritical;
+    }
+    // the random factor is applied between the crit mod and the stab mod, so don't apply anything below this until we're inside the loop
+    //see GENERAL MODS CONTINUED for further comments
+
+    var stabMod = 0x1000;
+    if (move.type === attacker.type1 || move.type === attacker.type2) {
+        if (attacker.ability === "Adaptability") {
+            stabMod = 0x2000;
+            description.attackerAbility = attacker.ability;
+        } else {
+            stabMod = 0x1800;
+        }
+    } else if (attacker.ability === "Protean" || attacker.ability == "Libero") {
+        stabMod = 0x1800;
+        description.attackerAbility = attacker.ability;
+    }
+    var applyBurn = (attacker.status === "Burned" && move.category === "Physical" && attacker.ability !== "Guts" && !move.ignoresBurn);
+    description.isBurned = applyBurn;
+    var finalMod;
+    [finalMod, description] = calcFinalMods(move, attacker, defender, field, description, isCritical, typeEffectiveness, defAbility);
+    finalMods = chainMods(finalMod);
+
+    var damage = [], pbDamage = [];
+    var child, childDamage, j;
+    var childMove, child2Damage, tripleDamage = [];
+
+    if (typeof (move.tripleHit2) === 'undefined') {
+        if (move.isTripleHit) {
+            if (move.tripleHits > 1) {
+                childMove = move;
+                childMove.tripleHit2 = true;
+                childDamage = GET_DAMAGE_SS(attacker, defender, childMove, field).damage;
+                if (move.tripleHits > 2) {
+                    childMove.tripleHit3 = true;
+                    child2Damage = GET_DAMAGE_SS(attacker, defender, childMove, field).damage;
+                    childMove.tripleHit3 = false;
+                }
+                childMove.tripleHit2 = false;
+            }
+            description.hits = move.tripleHits;
+        }
+        else if (attacker.ability === "Parental Bond" && move.hits === 1 && (field.format === "Singles" || !move.isSpread)) {
+            child = JSON.parse(JSON.stringify(attacker));
+            child.ability = '';
+            child.isChild = true;
+            childMove = move;
+            if (move.name === 'Power-Up Punch') {
+                child.boosts[AT]++;
+                child.stats[AT] = getModifiedStat(child.rawStats[AT], child.boosts[AT]);
+            }
+            else if (move.name === 'Assurance') {
+                childMove.isDouble = 1;
+            }
+            childDamage = GET_DAMAGE_SS(child, defender, childMove, field).damage;
+            description.attackerAbility = attacker.ability;
+        }
+    }
+    //GENERAL MODS CONTINUED
+    for (var i = 0; i < 16; i++) { //e. Rand mod
+        damage[i] = Math.floor(baseDamage * (85 + i) / 100);
+        //f. STAB mod
+        damage[i] = pokeRound(damage[i] * stabMod / 0x1000);
+        //g. Type Effect mod
+        damage[i] = Math.floor(damage[i] * typeEffectiveness);
+        //h. Burn mod
+        if (applyBurn) {
+            damage[i] = Math.floor(damage[i] / 2);
+        }
+        //i. Final mods
+        damage[i] = pokeRound(damage[i] * finalMods / 0x1000);
+        //j. Z-move and Max move protecting mod
+        if (isQuarteredByProtect) {
+            damage[i] = pokeRound(damage[i] * 0x400 / 0x1000);
+            description.isQuarteredByProtect = true;
+        }
+        //k. Min Damage Check
+        damage[i] = Math.max(1, damage[i]);
+        //l. Max Damage Check
+        if (damage[i] > 65535)
+            damage[i] %= 65536;
+
+        //Parental Bond child hit and Triple Kick/Axel second/third hit logic
+        if (typeof (move.tripleHit2) !== 'undefined' && move.tripleHit2 === false && move.isTripleHit) {
+            for (j = 0; j < 16; j++) {
+                if (typeof (move.tripleHit3) !== 'undefined' && move.tripleHit3 === false) {
+                    for (k = 0; k < 16; k++) {
+                        tripleDamage[(16 * i) + (16 * j) + k] = damage[i] + childDamage[j] + child2Damage[k];
+                    }
+                }
+                else {
+                    tripleDamage[(16 * i) + j] = damage[i] + childDamage[j];
+                }
+            }
+        }
+        else if (attacker.ability === "Parental Bond" && move.hits === 1 && !move.isTripleHit && (field.format === "Singles" || !move.isSpread)) {
+            for (j = 0; j < 16; j++) {
+                pbDamage[(16 * i) + j] = damage[i] + childDamage[j];
+            }
+        }
+    }
+    // Return a bit more info if this is a Parental Bond usage.
+    if (pbDamage.length) {
+        return {
+            "damage": pbDamage.sort(numericSort),
+            "parentDamage": damage,
+            "childDamage": childDamage,
+            "description": buildDescriptionSS(description)
+        };
+    }
+
+    if (tripleDamage.length) {
+        return {
+            "damage": tripleDamage.sort(numericSort),
+            "parentDamage": damage,
+            "childDamage": childDamage,
+            "child2Damage": move.tripleHits > 2 ? child2Damage : -1,
+            "description": buildDescriptionSS(description)
+        };
+    }
+
+    return {
+        "damage": pbDamage.length ? pbDamage.sort(numericSort) :
+            tripleDamage.length ? tripleDamage.sort(numericSort) :
+                damage,
+        "description": buildDescriptionSS(description)
+    };
+}
+
+//9. Finals Damage Mods
+function calcFinalMods(move, attacker, defender, field, description, isCritical, typeEffectiveness, defAbility) {
+    var finalMods = [];
+    //a. Screens
+    //There's no Aurora Veil because it affects damage identically and can't stack with Reflect and Light Screen but it can always be added later
+    if (field.isReflect && move.category === "Physical" && !isCritical && move.name !== "Brick Break" && move.name !== "Psychic Fangs") {
+        finalMods.push(field.format !== "Singles" ? 0xAAC : 0x800);
+        description.isReflect = true;
+    } else if (field.isLightScreen && move.category === "Special" && !isCritical) {
+        finalMods.push(field.format !== "Singles" ? 0xAAC : 0x800);
+        description.isLightScreen = true;
+    }
+    if (defender.isDynamax) description.isDynamax = true;
+    //b. Neuroforce
+    if (attacker.ability === "Neuroforce" && typeEffectiveness > 1) {
+        finalMods.push(0x1400);
+        description.attackerAbility = attacker.ability;
+    }
+    //c. Sniper
+    if (attacker.ability === "Sniper" && isCritical) {
+        finalMods.push(0x1800);
+        description.attackerAbility = attacker.ability;
+    }
+    //d. Tinted Lens
+    if (attacker.ability === "Tinted Lens" && typeEffectiveness < 1) {
+        finalMods.push(0x2000);
+        description.attackerAbility = attacker.ability;
+    }
+    //e. Dynamax Cannon, Behemoth Blade, Behemoth Bash
+    if ((move.name === "Dynamax Cannon" || move.name === "Behemoth Blade" || move.name === "Behemoth Bash") && defender.isDynamax) {
+        finalMods.push(0x2000);
+    }
+    //f. Multiscale, Shadow Shield
+    if ((defAbility === "Multiscale" || defAbility == "Shadow Shield") && defender.curHP === defender.maxHP) {
+        finalMods.push(0x800);
+        description.defenderAbility = defAbility;
+    }
+    //g. Fluffy (contact)
+    if (defAbility === "Fluffy" && move.makesContact) {
+        finalMods.push(0x800);
+        description.defenderAbility = defAbility;
+    }
+    //h. Punk Rock
+    if (defAbility === "Punk Rock" && move.isSound) {
+        finalMods.push(0x800);
+        description.defenderAbility = defAbility;
+    }
+    //i. Friend Guard
+    if (field.isFriendGuard) {
+        finalMods.push(0xC00);
+        description.isFriendGuard = true;
+    }
+    //j. Solid Rock, Filter, Prism Armor
+    if ((defAbility === "Solid Rock" || defAbility === "Filter" || defAbility === "Prism Armor") && typeEffectiveness > 1) {
+        finalMods.push(0xC00);
+        description.defenderAbility = defAbility;
+    }
+    //k. Metronome item
+    //l. Fluffy (fire moves)
+    if (defAbility === "Fluffy" && move.type === "Fire") {
+        finalMods.push(0x2000);
+        description.defenderAbility = defAbility;
+    }
+    //m. Expert Belt
+    if (attacker.item === "Expert Belt" && typeEffectiveness > 1) {
+        finalMods.push(0x1333);
+        description.attackerItem = attacker.item;
+    } //n. Life Orb
+    else if (attacker.item === "Life Orb") {
+        finalMods.push(0x14CC);
+        description.attackerItem = attacker.item;
+    }
+    //o. Resist Berries
+    if (getBerryResistType(defender.item) === move.type && (typeEffectiveness > 1 || move.type === "Normal") &&
+        attacker.ability !== "Unnerve" && attacker.ability !== "As One") {
+        if (defAbility === "Ripen") {
+            finalMods.push(0x400);
+            description.defenderAbility = defAbility;
+        }
+        else {
+            finalMods.push(0x800);
+        }
+        description.defenderItem = defender.item;
+    }
+    //p. Doubled damage
+    //p.i. Body Slam, Stomp, Dragon Rush, Steamroller, Heat Crash, Heavy Slam, Flying Press, Malicious Moonsault
+    //p.ii. Earthquake
+    //p.iii. Surf, Whirlpool
+    return [finalMods, description];
+}

--- a/script_res/item_data.js
+++ b/script_res/item_data.js
@@ -149,6 +149,7 @@ var ITEMS_DPP = ITEMS_ADV.concat([
     'Lagging Tail',
     'Lax Incense',
     'Light Clay',
+    'Mental Herb',
     'Metronome',
     'Power Herb',
     'Quick Powder',
@@ -172,7 +173,6 @@ var ITEMS_GEMS = [
     'Grass Gem',
     'Ground Gem',
     'Ice Gem',
-    'Normal Gem',
     'Poison Gem',
     'Psychic Gem',
     'Rock Gem',
@@ -196,6 +196,7 @@ var ITEMS_BW_NO_GEMS = ITEMS_DPP.concat([
     'Red Card',
     'Ring Target',  //Might implement
     'Rocky Helmet',
+    'Normal Gem',
 ]);
 
 var ITEMS_BW = ITEMS_BW_NO_GEMS.concat(ITEMS_GEMS);
@@ -511,20 +512,29 @@ function getFlingPower(item) {
 
 function getNaturalGift(item) {
     var gift = {
-        'Apicot Berry' : {'t':'Ground','p':100},
+        'Aguav Berry': { 't': 'Dragon', 'p': 80 },
+        'Apicot Berry': { 't': 'Ground', 'p': 100 },
+        'Aspear Berry': { 't': 'Ice', 'p': 80 },
         'Babiri Berry' : {'t':'Steel','p':80},
-        'Belue Berry' : {'t':'Electric','p':100},
-        'Charti Berry' : {'t':'Rock','p':80},
+        'Belue Berry': { 't': 'Electric', 'p': 100 },
+        'Bluk Berry': { 't': 'Fire', 'p': 90 },
+        'Charti Berry': { 't': 'Rock', 'p': 80 },
+        'Cheri Berry': { 't': 'Fire', 'p': 80 },
         'Chesto Berry' : {'t':'Water','p':80},
         'Chilan Berry' : {'t':'Normal','p':80},
         'Chople Berry' : {'t':'Fighting','p':80},
         'Coba Berry' : {'t':'Flying','p':80},
-        'Colbur Berry' : {'t':'Dark','p':80},
+        'Colbur Berry': { 't': 'Dark', 'p': 80 },
+        'Cornn Berry': { 't': 'Bug', 'p': 90 },
         'Custap Berry' : {'t':'Ghost','p':100},
         'Durin Berry' : {'t':'Water','p':100},
-        'Enigma Berry' : {'t':'Bug','p':100},
-        'Ganlon Berry' : {'t':'Ice','p':100},
-        'Haban Berry' : {'t':'Dragon','p':80},
+        'Enigma Berry': { 't': 'Bug', 'p': 100 },
+        'Figy Berry': { 't': 'Bug', 'p': 80 },
+        'Ganlon Berry': { 't': 'Ice', 'p': 100 },
+        'Grepa Berry': { 't': 'Flying', 'p': 90 },
+        'Haban Berry': { 't': 'Dragon', 'p': 80 },
+        'Hondew Berry': { 't': 'Ground', 'p': 90 },
+        'Iapapa Berry': { 't': 'Dark', 'p': 80 },
         'Jaboca Berry' : {'t':'Dragon','p':100},
         'Kasib Berry' : {'t':'Ghost','p':80},
         'Kebia Berry' : {'t':'Poison','p':80},
@@ -532,25 +542,41 @@ function getNaturalGift(item) {
         'Lansat Berry' : {'t':'Flying','p':100},
         'Leppa Berry' : {'t':'Fighting','p':80},
         'Liechi Berry' : {'t':'Grass','p':100},
-        'Lum Berry' : {'t':'Flying','p':80},
+        'Lum Berry': { 't': 'Flying', 'p': 80 },
+        'Mago Berry': { 't': 'Ghost', 'p': 80 },
+        'Magost Berry': { 't': 'Rock', 'p': 90 },
         'Maranga Berry' : {'t':'Dark','p':100},
-        'Micle Berry' : {'t':'Rock','p':100},
+        'Micle Berry': { 't': 'Rock', 'p': 100 },
+        'Nanab Berry': { 't': 'Water', 'p': 90 },
+        'Nomel Berry': { 't': 'Dragon', 'p': 90 },
         'Occa Berry' : {'t':'Fire','p':80},
-        'Oran Berry' : {'t':'Poison','p':80},
+        'Oran Berry': { 't': 'Poison', 'p': 80 },
+        'Pamtre Berry': { 't': 'Steel', 'p': 90 },
         'Passho Berry' : {'t':'Water','p':80},
-        'Payapa Berry' : {'t':'Psychic','p':80},
-        'Petaya Berry' : {'t':'Poison','p':100},
-        'Rawst Berry' : {'t':'Grass','p':80},
+        'Payapa Berry': { 't': 'Psychic', 'p': 80 },
+        'Pecha Berry': { 't': 'Electric', 'p': 80 },
+        'Persim Berry': { 't': 'Ground', 'p': 80 },
+        'Petaya Berry': { 't': 'Poison', 'p': 100 },
+        'Pinap Berry': { 't': 'Grass', 'p': 90 },
+        'Pomeg Berry': { 't': 'Ice', 'p': 90 },
+        'Qualot Berry': { 't': 'Poison', 'p': 90 },
+        'Rabuta Berry': { 't': 'Ghost', 'p': 90 },
+        'Rawst Berry': { 't': 'Grass', 'p': 80 },
+        'Razz Berry': { 't': 'Steel', 'p': 80 },
         'Rindo Berry' : {'t':'Grass','p':80},
         'Roseli Berry' : {'t':'Fairy','p':80},
         'Rowap Berry' : {'t':'Dark','p':100},
         'Salac Berry' : {'t':'Fighting','p':100},
         'Shuca Berry' : {'t':'Ground','p':80},
-        'Sitrus Berry' : {'t':'Psychic','p':80},
-        'Starf Berry' : {'t':'Psychic','p':100},
+        'Sitrus Berry': { 't': 'Psychic', 'p': 80 },
+        'Spelon Berry': { 't': 'Dark', 'p': 90 },
+        'Starf Berry': { 't': 'Psychic', 'p': 100 },
+        'Tamato Berry': { 't': 'Psychic', 'p': 90 },
         'Tanga Berry' : {'t':'Bug','p':80},
         'Wacan Berry' : {'t':'Electric','p':80},
-        'Watmel Berry' : {'t':'Fire','p':100},
+        'Watmel Berry': { 't': 'Fire', 'p': 100 },
+        'Wepear Berry': { 't': 'Electric', 'p': 90 },
+        'Wiki Berry': { 't': 'Rock', 'p': 80 },
         'Yache Berry' : {'t':'Ice','p':80}
     }[item];
     if (gift) {
@@ -610,101 +636,151 @@ function getZType(item) {
 }
 
 //FIX THIS CODE TO MATCH THIS EXAMPLE: 'Abomasite': 'Abomasnow'
-var MEGA_STONE_USER_LOOKUP = [
-['Abomasite', 'Abomasnow'],
-['Absolite', 'Absol'],
-['Aerodactylite', 'Aerodactyl'],
-['Aggronite', 'Aggron'],
-['Alakazite', 'Alakazam'],
-['Ampharosite', 'Ampharos'],
-['Banettite', 'Banette'],
-['Blastoisinite', 'Blastoise'],
-['Blazikenite', 'Blaziken'],
-['Charizardite X', 'Charizard'],
-['Charizardite Y', 'Charizard'],
-['Garchompite', 'Garchomp'],
-['Gardevoirite', 'Gardevoir'],
-['Gengarite', 'Gengar'],
-['Gyaradosite', 'Gyarados'],
-['Heracronite', 'Heracross'],
-['Houndoominite', 'Houndoom'],
-['Kangaskhanite', 'Kangaskhan'],
-['Latiasite', 'Latias'],
-['Latiosite', 'Latios'],
-['Lucarionite', 'Lucario'],
-['Manectite', 'Manectric'],
-['Mawilite', 'Mawile'],
-['Medichamite', 'Medicham'],
-['Mewtwonite X', 'Mewtwo'],
-['Mewtwonite Y', 'Mewtwo'],
-['Pinsirite', 'Pinsir'],
-['Scizorite', 'Scizor'],
-['Tyranitarite', 'Tyranitar'],
-['Venusaurite', 'Venusaur'],
-['Altarianite', 'Altaria'],
-['Audinite', 'Audino'],
-['Beedrillite', 'Beedrill'],
-['Cameruptite', 'Camerupt'],
-['Diancite', 'Diancie'],
-['Galladite', 'Gallade'],
-['Glalitite', 'Glalie'],
-['Lopunnite', 'Lopunny'],
-['Metagrossite', 'Metagross'],
-['Pidgeotite', 'Pidgeot'],
-['Sablenite', 'Sableye'],
-['Salamencite', 'Salamence'],
-['Sceptilite', 'Sceptile'],
-['Sharpedonite', 'Sharpedo'],
-['Slowbronite', 'Slowbro'],
-['Steelixite', 'Steelix'],
-['Swampertite', 'Swampert'],
-['Red Orb', 'Groudon'],
-['Blue Orb', 'Kyogre'],
-];
+//var MEGA_STONE_USER_LOOKUP = [
+//['Abomasite', 'Abomasnow'],
+//['Absolite', 'Absol'],
+//['Aerodactylite', 'Aerodactyl'],
+//['Aggronite', 'Aggron'],
+//['Alakazite', 'Alakazam'],
+//['Ampharosite', 'Ampharos'],
+//['Banettite', 'Banette'],
+//['Blastoisinite', 'Blastoise'],
+//['Blazikenite', 'Blaziken'],
+//['Charizardite X', 'Charizard'],
+//['Charizardite Y', 'Charizard'],
+//['Garchompite', 'Garchomp'],
+//['Gardevoirite', 'Gardevoir'],
+//['Gengarite', 'Gengar'],
+//['Gyaradosite', 'Gyarados'],
+//['Heracronite', 'Heracross'],
+//['Houndoominite', 'Houndoom'],
+//['Kangaskhanite', 'Kangaskhan'],
+//['Latiasite', 'Latias'],
+//['Latiosite', 'Latios'],
+//['Lucarionite', 'Lucario'],
+//['Manectite', 'Manectric'],
+//['Mawilite', 'Mawile'],
+//['Medichamite', 'Medicham'],
+//['Mewtwonite X', 'Mewtwo'],
+//['Mewtwonite Y', 'Mewtwo'],
+//['Pinsirite', 'Pinsir'],
+//['Scizorite', 'Scizor'],
+//['Tyranitarite', 'Tyranitar'],
+//['Venusaurite', 'Venusaur'],
+//['Altarianite', 'Altaria'],
+//['Audinite', 'Audino'],
+//['Beedrillite', 'Beedrill'],
+//['Cameruptite', 'Camerupt'],
+//['Diancite', 'Diancie'],
+//['Galladite', 'Gallade'],
+//['Glalitite', 'Glalie'],
+//['Lopunnite', 'Lopunny'],
+//['Metagrossite', 'Metagross'],
+//['Pidgeotite', 'Pidgeot'],
+//['Sablenite', 'Sableye'],
+//['Salamencite', 'Salamence'],
+//['Sceptilite', 'Sceptile'],
+//['Sharpedonite', 'Sharpedo'],
+//['Slowbronite', 'Slowbro'],
+//['Steelixite', 'Steelix'],
+//['Swampertite', 'Swampert'],
+//['Red Orb', 'Groudon'],
+//['Blue Orb', 'Kyogre'],
+//];
+var MEGA_STONE_USER_LOOKUP = {
+    'Abomasite': 'Abomasnow',
+    'Absolite': 'Absol',
+    'Aerodactylite': 'Aerodactyl',
+    'Aggronite': 'Aggron',
+    'Alakazite': 'Alakazam',
+    'Ampharosite': 'Ampharos',
+    'Banettite': 'Banette',
+    'Blastoisinite': 'Blastoise',
+    'Blazikenite': 'Blaziken',
+    'Charizardite X': 'Charizard',
+    'Charizardite Y': 'Charizard',
+    'Garchompite': 'Garchomp',
+    'Gardevoirite': 'Gardevoir',
+    'Gengarite': 'Gengar',
+    'Gyaradosite': 'Gyarados',
+    'Heracronite': 'Heracross',
+    'Houndoominite': 'Houndoom',
+    'Kangaskhanite': 'Kangaskhan',
+    'Latiasite': 'Latias',
+    'Latiosite': 'Latios',
+    'Lucarionite': 'Lucario',
+    'Manectite': 'Manectric',
+    'Mawilite': 'Mawile',
+    'Medichamite': 'Medicham',
+    'Mewtwonite X': 'Mewtwo',
+    'Mewtwonite Y': 'Mewtwo',
+    'Pinsirite': 'Pinsir',
+    'Scizorite': 'Scizor',
+    'Tyranitarite': 'Tyranitar',
+    'Venusaurite': 'Venusaur',
+    'Altarianite': 'Altaria',
+    'Audinite': 'Audino',
+    'Beedrillite': 'Beedrill',
+    'Cameruptite': 'Camerupt',
+    'Diancite': 'Diancie',
+    'Galladite': 'Gallade',
+    'Glalitite': 'Glalie',
+    'Lopunnite': 'Lopunny',
+    'Metagrossite': 'Metagross',
+    'Pidgeotite': 'Pidgeot',
+    'Sablenite': 'Sableye',
+    'Salamencite': 'Salamence',
+    'Sceptilite': 'Sceptile',
+    'Sharpedonite': 'Sharpedo',
+    'Slowbronite': 'Slowbro',
+    'Steelixite': 'Steelix',
+    'Swampertite': 'Swampert',
+    'Red Orb': 'Groudon',
+    'Blue Orb': 'Kyogre',
+};
 
 function canMega(item, species) {
-    for (var i = 0; i < MEGA_STONE_USER_LOOKUP.length; i++) {
-        var tempMega = MEGA_STONE_USER_LOOKUP[i];
-        if (tempMega[0] == item && species.includes(tempMega[1]))
-            return true;
-    }
-    return false;
+    return MEGA_STONE_USER_LOOKUP[item] === species;
 }
 
-var SIGNATURE_Z_MOVE_LOOKUP = [
-    ['Aloraichium Z', 'Raichu-Alola', 'Thunderbolt', 'Stoked Sparksurfer'],
-    ['Decidium Z', 'Decidueye', 'Spirit Shackle', 'Sinister Arrow Raid'],
-    ['Eevium Z', 'Eevee', 'Last Resort', 'Extreme Evoboost'],
-    ['Incinium Z', 'Incineroar', 'Darkest Lariat', 'Malicious Moonsault'],
-    ['Marshadium Z', 'Marshadow', 'Spectral Thief', 'Soul-Stealing 7-Star Strike'],
-    ['Mewnium Z', 'Mew', 'Psychic', 'Genesis Supernova'],
-    ['Pikanium Z', 'Pikachu', 'Volt Tackle', 'Catastropika'],
-    ['Pikashunium Z', 'Pikachu', 'Thunderbolt', '10,000,000 Volt Thunderbolt'],
-    ['Primarium Z', 'Primarina', 'Sparkling Aria', 'Oceanic Operetta'],
-    ['Snorlium Z', 'Snorlax', 'Giga Impact', 'Pulverizing Pancake'],
-    ['Tapunium Z', 'Tapu Koko', 'Nature\'s Madness', 'Guardian of Alola'],
-    ['Tapunium Z', 'Tapu Lele', 'Nature\'s Madness', 'Guardian of Alola'],
-    ['Tapunium Z', 'Tapu Bulu', 'Nature\'s Madness', 'Guardian of Alola'],
-    ['Tapunium Z', 'Tapu Fini', 'Nature\'s Madness', 'Guardian of Alola'],
-    ['Kommonium Z', 'Kommo-o', 'Clanging Scales', 'Clangerous Soulblaze'],
-    ['Lunalium Z', 'Lunala', 'Moongeist Beam', 'Menacing Moonraze Maelstrom'],
-    ['Lunalium Z', 'Necrozma-Dawn-Wings', 'Moongeist Beam', 'Menacing Moonraze Maelstrom'],
-    ['Lycanium Z', 'Lycanroc-Midday', 'Stone Edge', 'Splintered Stormshards'],
-    ['Lycanium Z', 'Lycanroc-Midnight', 'Stone Edge', 'Splintered Stormshards'],
-    ['Lycanium Z', 'Lycanroc-Dusk', 'Stone Edge', 'Splintered Stormshards'],
-    ['Mimikium Z', 'Mimikyu', 'Play Rough', 'Let\'s Snuggle Forever'],
-    ['Solganium Z', 'Solgaleo', 'Sunsteel Strike', 'Searing Sunraze Smash'],
-    ['Solganium Z', 'Necrozma-Dusk-Mane', 'Sunsteel Strike', 'Searing Sunraze Smash'],
-    ['Ultranecrozium Z', 'Ultra Necrozma', 'Photon Geyser', 'Light That Burns the Sky']
-];
+var SIGNATURE_Z_MOVE_LOOKUP = {
+    'Raichu-Alola': { 'Aloraichium Z': { 'Thunderbolt': 'Stoked Sparksurfer' } },
+    'Decidueye': { 'Decidium Z': { 'Spirit Shackle': 'Sinister Arrow Raid' } },
+    'Eevee': { 'Eevium Z': { 'Last Resort': 'Extreme Evoboost' } },
+    'Incineroar': { 'Incinium Z': { 'Darkest Lariat': 'Malicious Moonsault' } },
+    'Marshadow': { 'Marshadium Z': { 'Spectral Thief': 'Soul-Stealing 7-Star Strike' } },
+    'Mew': { 'Mewnium Z': { 'Psychic': 'Genesis Supernova' } },
+    'Pikachu': {
+        'Pikanium Z': { 'Volt Tackle': 'Catastropika' },
+        'Pikashunium Z': { 'Thunderbolt': '10,000,000 Volt Thunderbolt' }
+    },
+    'Primarina': { 'Primarium Z': { 'Sparkling Aria': 'Oceanic Operetta' } },
+    'Snorlax': { 'Snorlium Z': { 'Giga Impact': 'Pulverizing Pancake' } },
+    'Tapu Koko': { 'Tapunium Z': { 'Nature\'s Madness': 'Guardian of Alola' } },
+    'Tapu Lele': { 'Tapunium Z': { 'Nature\'s Madness': 'Guardian of Alola' } },
+    'Tapu Bulu': { 'Tapunium Z': { 'Nature\'s Madness': 'Guardian of Alola' } },
+    'Tapu Fini': { 'Tapunium Z': { 'Nature\'s Madness': 'Guardian of Alola' } },
+    'Kommo-o': { 'Kommonium Z': { 'Clanging Scales': 'Clangorous Soulblaze' } },
+    'Lunala': { 'Lunalium Z': { 'Moongeist Beam': 'Menacing Moonraze Maelstrom' } },
+    'Necrozma-Dawn-Wings': { 'Lunalium Z': { 'Moongeist Beam': 'Menacing Moonraze Maelstrom' } },
+    'Lycanroc-Midday': { 'Lycanium Z': { 'Stone Edge': 'Splintered Stormshards' } },
+    'Lycanroc-Midnight': { 'Lycanium Z': { 'Stone Edge': 'Splintered Stormshards' } },
+    'Lycanroc-Dusk': { 'Lycanium Z': { 'Stone Edge': 'Splintered Stormshards' } },
+    'Mimikyu': { 'Mimikium Z': { 'Play Rough': 'Let\'s Snuggle Forever' } },
+    'Solgaleo': { 'Solganium Z': { 'Sunsteel Strike': 'Searing Sunraze Smash' } },
+    'Necrozma-Dusk-Mane': { 'Solganium Z': { 'Sunsteel Strike': 'Searing Sunraze Smash' } },
+    'Ultra Necrozma': { 'Ultranecrozium Z': { 'Photon Geyser': 'Light That Burns the Sky' } }
+};
 
 function getSignatureZMove(item, species, move) {
-    var tempZ;
-    for (var i = 0; i < SIGNATURE_Z_MOVE_LOOKUP.length; i++) {
-        tempZ = SIGNATURE_Z_MOVE_LOOKUP[i];
-        if (tempZ[0] == item && tempZ[1] == species && tempZ[2] == move) return tempZ[3];
-    }
-    return -1;
+    //var tempZ;
+    //for (var i = 0; i < SIGNATURE_Z_MOVE_LOOKUP.length; i++) {
+    //    tempZ = SIGNATURE_Z_MOVE_LOOKUP[i];
+    //    if (tempZ[0] == item && tempZ[1] == species && tempZ[2] == move) return tempZ[3];
+    //}
+    var isSigZ = SIGNATURE_Z_MOVE_LOOKUP[species] && SIGNATURE_Z_MOVE_LOOKUP[species][item] && SIGNATURE_Z_MOVE_LOOKUP[species][item][move]
+        ? SIGNATURE_Z_MOVE_LOOKUP[species][item][move] : -1;
+    return isSigZ;
 }
 
 var LOCK_ITEM_LOOKUP = {
@@ -762,3 +838,22 @@ var LOCK_ITEM_LOOKUP = {
     'Zacian-Crowned': 'Rusted Sword',
     'Zamazenta-Crowned': 'Rusted Shield',
 };
+
+function cantRemoveItem(defItem, defSpecies, terrain) {
+    return defItem === null || defItem === "" || defItem.indexOf("ium Z") !== -1
+        || LOCK_ITEM_LOOKUP[defSpecies] === defItem
+        || defItem === terrain + " Seed"
+        || (defSpecies === "Arceus" && defItem.indexOf(" Plate") !== -1)
+        || (defSpecies === "Genesect" && defItem.indexOf(" Drive") !== -1)
+        || (defSpecies === "Silvally" && defItem.indexOf(" Memory") !== -1);
+}
+
+function cantFlingItem(atItem, atSpecies, defAbility) {
+    return atItem === "" || atItem.indexOf(" Gem") !== -1 || atItem.indexOf(" ium Z") !== -1 || ["Red Orb", "Blue Orb", "Rusted Sword", "Rusted Shield"].indexOf(atItem) !== -1
+        || (atSpecies === 'Giratina-Origin' && atItem === "Griseous Orb")
+        || (atSpecies === 'Arceus' && atItem.indexOf(" Plate") !== -1)
+        || (atSpecies === 'Genesect' && atItem.indexOf(" Drive") !== -1)
+        || (atSpecies === 'Silvally' && atItem.indexOf(" Memory") !== -1)
+        || canMega(atItem, atSpecies)
+        || (["As One", "Unnerve"].indexOf(defAbility) !== -1 && atItem.indexOf(" Berry") !== -1);
+}

--- a/script_res/ko_chance.js
+++ b/script_res/ko_chance.js
@@ -148,7 +148,7 @@ function getKOChanceText(damage, move, defender, field, isBadDreams) {
 
     // multi-hit moves have too many possibilities for brute-forcing to work, so reduce it to an approximate distribution
     var qualifier = '';
-    if (move.hits > 1) {
+    if (move.hits > 1 && !move.isTripleHit) {
         qualifier = 'approx. ';
         damage = squashMultihit(damage, move.hits);
     }

--- a/script_res/move_data.js
+++ b/script_res/move_data.js
@@ -253,197 +253,197 @@ var MOVES_RBY = {
     },
     'Swords Dance': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Whirlwind': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Tail Whip': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Leer': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Growl': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Roar': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Sing': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Disable': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Mist': {
         
-        type: '',
+        type: 'Ice',
         category: 'Status'
     },
     'Leech Seed': {
         
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Growth': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Stun Spore': {
         
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Sleep Powder': {
         
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'String Shot': {
         
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Thunder Wave': {
         
-        type: '',
+        type: 'Electric',
         category: 'Status'
     },
     'Toxic': {
         
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Hypnosis': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Agility': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Teleport': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Screech': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Double Team': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Recover': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Minimize': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Barrier': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Light Screen': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Haze': {
         
-        type: '',
+        type: 'Ice',
         category: 'Status'
     },
     'Reflect': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Focus Energy': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Amnesia': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Soft-Boiled': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Glare': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Poison Gas': {
         
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Lovely Kiss': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Transform': {
         
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Spore': {
         
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Acid Armor': {
         
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Rest': {
         
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Conversion': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Substitute': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
 };
@@ -726,147 +726,147 @@ var MOVES_GSC = $.extend(true, {}, MOVES_RBY, {
     },
     'Mind Reader': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Curse': {
 
-        type: '',
+        type: 'Ghost',
         category: 'Status'
     },
     'Cotton Spore': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Protect': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Scary Face': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Belly Drum': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Spikes': {
 
-        type: '',
+        type: 'Ground',
         category: 'Status'
     },
     'Foresight': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Desting Bond': {
 
-        type: '',
+        type: 'Ghost',
         category: 'Status'
     },
     'Perish Song': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Detect': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Lock-On': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Sandstorm': {
 
-        type: '',
+        type: 'Rock',
         category: 'Status'
     },
     'Endure': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Charm': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Swagger': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Milk Drink': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Sleep Talk': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Heal Bell': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Safeguard': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Baton Pass': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Encore': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Sweet Scent': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Morning Sun': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Synthesis': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Moonlight': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Rain Dance': {
 
-        type: '',
+        type: 'Water',
         category: 'Status'
     },
     'Sunny Day': {
 
-        type: '',
+        type: 'Fire',
         category: 'Status'
     },
     'Psych Up': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
 });
@@ -1144,187 +1144,187 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
     },
     'Stockpile': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Hail': {
 
-        type: '',
+        type: 'Ice',
         category: 'Status'
     },
     'Torment': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Flatter': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Will-O-Wisp': {
 
-        type: '',
+        type: 'Fire',
         category: 'Status'
     },
     'Memento': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Follow Me': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Taunt': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Helping Hand': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Trick': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Role Play': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Wish': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Assist': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Ingrain': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Magic Coat': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Recycle': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Yawn': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Skill Swap': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Imprison': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Refresh': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Grudge': {
 
-        type: '',
+        type: 'Ghost',
         category: 'Status'
     },
     'Snatch': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Tail Glow': {
 
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Feather Dance': {
 
-        type: '',
+        type: 'Flying',
         category: 'Status'
     },
     'Teeter Dance': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Slack Off': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Aromatherapy': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Fake Tears': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Metal Sound': {
 
-        type: '',
+        type: 'Steel',
         category: 'Status'
     },
     'Grass Whistle': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Tickle': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Cosmic Power': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Iron Defense': {
 
-        type: '',
+        type: 'Steel',
         category: 'Status'
     },
     'Howl': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Bulk Up': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Calm Mind': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Dragon Dance': {
 
-        type: '',
+        type: 'Dragon',
         category: 'Status'
     },
 });
@@ -1849,132 +1849,132 @@ var MOVES_DPP = $.extend(true, {}, MOVES_ADV, {
     },
     'Roost': {
 
-        type: '',
+        type: 'Flying',
         category: 'Status'
     },
     'Gravity': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Healing Wish': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Tailwind': {
 
-        type: '',
+        type: 'Flying',
         category: 'Status'
     },
     'Acupressure': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Embargo': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Psycho Shift': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Heal Block': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Power Trick': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Gastro Acid': {
 
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Me First': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Copycat': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Power Swap': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Worry Seed': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Toxic Spikes': {
 
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Heart Swap': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Magnet Rise': {
 
-        type: '',
+        type: 'Electric',
         category: 'Status'
     },
     'Rock Polish': {
 
-        type: '',
+        type: 'Rock',
         category: 'Status'
     },
     'Switcheroo': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Nasty Plot': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Defog': {
 
-        type: '',
+        type: 'Flying',
         category: 'Status'
     },
     'Trick Room': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Captivate': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Stealth Rock': {
 
-        type: '',
+        type: 'Rock',
         category: 'Status'
     },
     'Lunar Dance': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Dark Void': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
 });
@@ -2389,21 +2389,21 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
         type: 'Water',
         category: 'Special',
     },
-    'Fire Pledge (Combined)': {
-        bp: 150,
-        type: 'Fire',
-        category: 'Special',
-    },
-    'Grass Pledge (Combined)': {
-        bp: 150,
-        type: 'Grass',
-        category: 'Special',
-    },
-    'Water Pledge (Combined)': {
-        bp: 150,
-        type: 'Water',
-        category: 'Special',
-    },
+    //'Fire Pledge (Combined)': {
+    //    bp: 150,
+    //    type: 'Fire',
+    //    category: 'Special',
+    //},
+    //'Grass Pledge (Combined)': {
+    //    bp: 150,
+    //    type: 'Grass',
+    //    category: 'Special',
+    //},
+    //'Water Pledge (Combined)': {
+    //    bp: 150,
+    //    type: 'Water',
+    //    category: 'Special',
+    //},
     'Heat Crash': {
         bp: 1,
         type: 'Fire',
@@ -2422,112 +2422,112 @@ var MOVES_BW = $.extend(true, {}, MOVES_DPP, {
     },
     'Hone Claws': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Wide Guard': {
 
-        type: '',
+        type: 'Rock',
         category: 'Status'
     },
     'Guard Split': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Power Split': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Autotomize': {
 
-        type: '',
+        type: 'Steel',
         category: 'Status'
     },
     'Rage Powder': {
 
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Magic Room': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Quiver Dance': {
 
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Soak': {
 
-        type: '',
+        type: 'Water',
         category: 'Status'
     },
     'Coil': {
 
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Simple Beam': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Entrainment': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'After You': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Quick Guard': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Ally Switch': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Shell Smash': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Heal Pulse': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Shift Gear': {
 
-        type: '',
+        type: 'Steel',
         category: 'Status'
     },
     'Quash': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Reflect Type': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Work Up': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Cotton Guard': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
 });
@@ -2753,87 +2753,87 @@ var MOVES_XY = $.extend(true, {}, MOVES_BW, {
     },
     'Mat Block': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Sticky Web': {
 
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Trick-or-Treat': {
 
-        type: '',
+        type: 'Ghost',
         category: 'Status'
     },
     'Forest\'s Curse': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Parting Shot': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Topsy-Turvy': {
 
-        type: '',
+        type: 'Dark',
         category: 'Status'
     },
     'Crafty Shield': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Grassy Terrain': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Misty Terrain': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Electrify': {
 
-        type: '',
+        type: 'Electric',
         category: 'Status'
     },
     'King\'s Shield': {
 
-        type: '',
+        type: 'Steel',
         category: 'Status'
     },
     'Spiky Shield': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Eerie Impulse': {
 
-        type: '',
+        type: 'Electric',
         category: 'Status'
     },
     'Powder': {
 
-        type: '',
+        type: 'Bug',
         category: 'Status'
     },
     'Geomancy': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Electric Terrain': {
 
-        type: '',
+        type: 'Electric',
         category: 'Status'
     },
     'Baby-Doll Eyes': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Techno Blast': {
@@ -3184,52 +3184,52 @@ var MOVES_SM = $.extend(true, {}, MOVES_XY, {
     },
     'Shore Up': {
 
-        type: '',
+        type: 'Ground',
         category: 'Status'
     },
     'Baneful Bunker': {
 
-        type: '',
+        type: 'Poison',
         category: 'Status'
     },
     'Floral Healing': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Strength Sap': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
     'Spotlight': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status'
     },
     'Psychic Terrain': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Speed Swap': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Instruct': {
 
-        type: '',
+        type: 'Psychic',
         category: 'Status'
     },
     'Aurora Veil': {
 
-        type: '',
+        type: 'Ice',
         category: 'Status'
     },
     'Extreme Evoboost': {
 
-        type: '',
+        type: 'Normal',
         category: 'Status',
         isSignatureZ: true,
     },
@@ -4208,6 +4208,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 80,
         type: 'Dark',
         category: 'Physical',
+        makesContact: true,
     },
     'Dragon Darts': {
         bp: 50,
@@ -4233,6 +4234,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 80,
         type: 'Fighting',
         category: 'Physical',
+        makesContact: true,
     },
     'Drum Beating': {
         bp: 80,
@@ -4243,6 +4245,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 35,
         type: 'Grass',
         category: 'Physical',
+        makesContact: true,
     },
     'Pyro Ball': {
         bp: 120,
@@ -4253,11 +4256,13 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 100,
         type: 'Steel',
         category: 'Physical',
+        makesContact: true,
     },
     'Behemoth Bash': {
         bp: 100,
         type: 'Steel',
         category: 'Physical',
+        makesContact: true,
     },
     'Aura Wheel': {
         bp: 110,
@@ -4269,11 +4274,13 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         type: 'Dragon',
         category: 'Physical',
         isSpread: true,
+        makesContact: true,
     },
     'Branch Poke': {
         bp: 40,
         type: 'Grass',
         category: 'Physical',
+        makesContact: true,
     },
     'Overdrive': {
         bp: 80,
@@ -4297,6 +4304,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         type: 'Fairy',
         category: 'Physical',
         hasSecondaryEffect: true,
+        makesContact: true,
     },
     'Strange Stream': {
         bp: 90,
@@ -4307,6 +4315,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 80,
         type: 'Dark',
         category: 'Physical',
+        makesContact: true,
     },
     'Meteor Assault': {
         bp: 150,
@@ -4590,7 +4599,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         type: 'Ice',
         category: 'Physical',
         makesContact: true,
-        isThreeHit: true
+        isTripleHit: true
     },
     'Wicked Blow': {
         bp: 80,
@@ -4646,32 +4655,32 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
     },
     'No Retreat': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Octolock': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Clangerous Soul': {
 
-        type: '',
+        type: 'Dragon',
         category: 'Status'
     },
     'Decorate': {
 
-        type: '',
+        type: 'Fairy',
         category: 'Status'
     },
     'Life Dew': {
 
-        type: '',
+        type: 'Water',
         category: 'Status'
     },
     'Coaching': {
 
-        type: '',
+        type: 'Fighting',
         category: 'Status'
     },
     'Double Iron Bash': {
@@ -4684,7 +4693,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
     },
     'Jungle Healing': {
 
-        type: '',
+        type: 'Grass',
         category: 'Status'
     },
 });
@@ -4809,10 +4818,8 @@ delete MOVES_SS['Frustration'];
 delete MOVES_SS['Jump Kick'];
 delete MOVES_SS['Mud Bomb'];
 delete MOVES_SS['Natural Gift'];
-delete MOVES_SS['Psycho Boost'];
 delete MOVES_SS['Pursuit'];
 delete MOVES_SS['Return'];
-delete MOVES_SS['Rock Climb'];
 delete MOVES_SS['Signal Beam'];
 delete MOVES_SS['Sky Drop'];
 delete MOVES_SS['Sky Uppercut'];
@@ -4869,4 +4876,22 @@ delete MOVES_SS['Hidden Power Flying'];
 delete MOVES_SS['Hidden Power Dragon'];
 delete MOVES_SS['Hidden Power Poison'];
 
-var MOVES_BDSP = $.extend(true, {}, MOVES_SS_NATDEX, {});
+var MOVES_SV = $.extend(true, {}, MOVES_SS_NATDEX, {
+    'Tera Blast': {
+        bp: 80,
+        type: 'Normal',
+        category: 'Special',
+    },
+});
+
+['Max Strike', 'Max Flare', 'Max Geyser', 'Max Lightning', 'Max Overgrowth',
+    'Max Phantasm', 'Max Darkness', 'Max Mindstorm', 'Max Knuckle', 'Max Steelspike',
+    'Max Hailstorm', 'Max Quake', 'Max Rockfall', 'Max Flutterby', 'Max Starfall',
+    'Max Airstream', 'Max Wyrmwind', 'Max Ooze', 'G-Max Wildfire', 'G-Max Befuddle',
+    'G-Max Volt Crash', 'G-Max Gold Rush', 'G-Max Chi Strike', 'G-Max Terror', 'G-Max Foam Burst',
+    'G-Max Resonance', 'G-Max Cuddle', 'G-Max Replenish', 'G-Max Malodor', 'G-Max Meltdown',
+    'G-Max Wind Rage', 'G-Max Gravitas', 'G-Max Stonesurge', 'G-Max Volcalith', 'G-Max Tartness',
+    'G-Max Sweetness', 'G-Max Sandblast', 'G-Max Stun Shock', 'G-Max Centinferno', 'G-Max Smite',
+    'G-Max Snooze', 'G-Max Finale', 'G-Max Steelsurge', 'G-Max Depletion', 'G-Max Vine Lash',
+    'G-Max Cannonade', 'G-Max Drum Solo', 'G-Max Fireball', 'G-Max Hydrosnipe',
+    'G-Max One Blow','G-Max Rapid Flow',].forEach(e => delete MOVES_SV[e]);

--- a/script_res/pokedex.js
+++ b/script_res/pokedex.js
@@ -10,7 +10,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 105
     },
-    "w": 19.5
+    "w": 19.5,
+        "ab": "Synchronize",
+        "canEvolve": true,
   },
   "Aerodactyl": {
     "t1": "Rock",
@@ -24,7 +26,8 @@ var POKEDEX_RBY = {
       "sp": 130,
       "sl": 60
     },
-    "w": 59.0
+      "w": 59.0,
+        "ab": "Pressure",
   },
   "Alakazam": {
     "t1": "Psychic",
@@ -37,7 +40,8 @@ var POKEDEX_RBY = {
       "sp": 120,
       "sl": 135
     },
-    "w": 48.0
+      "w": 48.0,
+      "ab": "Synchronize",
   },
   "Arbok": {
     "t1": "Poison",
@@ -50,7 +54,8 @@ var POKEDEX_RBY = {
       "sp": 80,
       "sl": 65
     },
-    "w": 65.0
+      "w": 65.0,
+      "ab": "Intimidate",
   },
   "Arcanine": {
     "t1": "Fire",
@@ -63,7 +68,8 @@ var POKEDEX_RBY = {
       "sp": 95,
       "sl": 80
     },
-    "w": 155.0
+      "w": 155.0,
+    "ab": "Intimidate",
   },
   "Articuno": {
     "t1": "Ice",
@@ -77,7 +83,8 @@ var POKEDEX_RBY = {
       "sp": 85,
       "sl": 125
     },
-    "w": 55.4
+      "w": 55.4,
+      "ab": "Pressure",
   },
   "Beedrill": {
     "t1": "Bug",
@@ -107,7 +114,8 @@ var POKEDEX_RBY = {
       "sl": 70
     },
     "w": 4.0,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Blastoise": {
     "t1": "Water",
@@ -136,7 +144,8 @@ var POKEDEX_RBY = {
       "sl": 65
     },
     "w": 6.9,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Butterfree": {
     "t1": "Bug",
@@ -151,7 +160,7 @@ var POKEDEX_RBY = {
       "sl": 80
     },
     "w": 32.0,
-    "ab": "Compoundeyes"
+    "ab": "Compound Eyes"
   },
   "Caterpie": {
     "t1": "Bug",
@@ -164,7 +173,9 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 20
     },
-    "w": 2.9
+      "w": 2.9,
+      "ab": "Shield Dust",
+      "canEvolve": true,
   },
   "Chansey": {
     "t1": "Normal",
@@ -177,7 +188,9 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 105
     },
-    "w": 34.6
+      "w": 34.6,
+      "ab": "Serene Grace",
+      "canEvolve": true,
   },
   "Charizard": {
     "t1": "Fire",
@@ -206,7 +219,8 @@ var POKEDEX_RBY = {
       "sl": 50
     },
     "w": 8.5,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Charmeleon": {
     "t1": "Fire",
@@ -220,7 +234,8 @@ var POKEDEX_RBY = {
       "sl": 65
     },
     "w": 19.0,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Clefable": {
     "t1": "Normal",
@@ -233,7 +248,8 @@ var POKEDEX_RBY = {
       "sp": 60,
       "sl": 85
     },
-    "w": 40.0
+      "w": 40.0,
+      "ab": "Cute Charm",
   },
   "Clefairy": {
     "t1": "Normal",
@@ -246,7 +262,9 @@ var POKEDEX_RBY = {
       "sp": 35,
       "sl": 60
     },
-    "w": 7.5
+      "w": 7.5,
+      "ab": "Cute Charm",
+      "canEvolve": true,
   },
   "Cloyster": {
     "t1": "Water",
@@ -274,7 +292,9 @@ var POKEDEX_RBY = {
       "sp": 35,
       "sl": 40
     },
-    "w": 6.5
+      "w": 6.5,
+      "ab": "Lightning Rod",
+      "canEvolve": true,
   },
   "Dewgong": {
     "t1": "Water",
@@ -302,7 +322,9 @@ var POKEDEX_RBY = {
       "sp": 95,
       "sl": 45
     },
-    "w": 0.8
+      "w": 0.8,
+      "ab": "Arena Trap",
+      "canEvolve": true,
   },
   "Ditto": {
     "t1": "Normal",
@@ -315,7 +337,8 @@ var POKEDEX_RBY = {
       "sp": 48,
       "sl": 48
     },
-    "w": 4.0
+      "w": 4.0,
+      "ab": "Limber",
   },
   "Dodrio": {
     "t1": "Normal",
@@ -329,7 +352,8 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 60
     },
-    "w": 85.2
+      "w": 85.2,
+      "ab": "Early Bird",
   },
   "Doduo": {
     "t1": "Normal",
@@ -343,7 +367,9 @@ var POKEDEX_RBY = {
       "sp": 75,
       "sl": 35
     },
-    "w": 39.2
+      "w": 39.2,
+      "ab": "Early Bird",
+      "canEvolve": true,
   },
   "Dragonair": {
     "t1": "Dragon",
@@ -356,7 +382,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 70
     },
-    "w": 16.5
+      "w": 16.5,
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Dragonite": {
     "t1": "Dragon",
@@ -370,7 +398,8 @@ var POKEDEX_RBY = {
       "sp": 80,
       "sl": 100
     },
-    "w": 210.0
+      "w": 210.0,
+      "ab": "Inner Focus",
   },
   "Dratini": {
     "t1": "Dragon",
@@ -383,7 +412,9 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 50
     },
-    "w": 3.3
+      "w": 3.3,
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Drowzee": {
     "t1": "Psychic",
@@ -396,7 +427,9 @@ var POKEDEX_RBY = {
       "sp": 42,
       "sl": 90
     },
-    "w": 32.4
+      "w": 32.4,
+      "ab": "Insomnia",
+      "canEvolve": true,
   },
   "Dugtrio": {
     "t1": "Ground",
@@ -409,7 +442,8 @@ var POKEDEX_RBY = {
       "sp": 120,
       "sl": 70
     },
-    "w": 33.3
+      "w": 33.3,
+      "ab": "Arena Trap",
   },
   "Eevee": {
     "t1": "Normal",
@@ -422,7 +456,9 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 65
     },
-    "w": 6.5
+      "w": 6.5,
+      "ab": "Run Away",
+      "canEvolve": true,
   },
   "Ekans": {
     "t1": "Poison",
@@ -435,7 +471,9 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 40
     },
-    "w": 6.9
+      "w": 6.9,
+      "ab": "Intimidate",
+      "canEvolve": true,
   },
   "Electabuzz": {
     "t1": "Electric",
@@ -448,7 +486,8 @@ var POKEDEX_RBY = {
       "sp": 105,
       "sl": 85
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Static",
   },
   "Electrode": {
     "t1": "Electric",
@@ -461,7 +500,8 @@ var POKEDEX_RBY = {
       "sp": 140,
       "sl": 80
     },
-    "w": 66.6
+      "w": 66.6,
+      "ab": "Soundproof",
   },
   "Exeggcute": {
     "t1": "Grass",
@@ -476,7 +516,8 @@ var POKEDEX_RBY = {
       "sl": 60
     },
     "w": 2.5,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Exeggutor": {
     "t1": "Grass",
@@ -505,7 +546,8 @@ var POKEDEX_RBY = {
       "sp": 60,
       "sl": 58
     },
-    "w": 15.0
+      "w": 15.0,
+      "ab": "Inner Focus",
   },
   "Fearow": {
     "t1": "Normal",
@@ -519,7 +561,8 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 61
     },
-    "w": 38.0
+      "w": 38.0,
+      "ab": "Keen Eye",
   },
   "Flareon": {
     "t1": "Fire",
@@ -548,7 +591,8 @@ var POKEDEX_RBY = {
       "sl": 100
     },
     "w": 0.1,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Gengar": {
     "t1": "Ghost",
@@ -577,7 +621,9 @@ var POKEDEX_RBY = {
       "sp": 20,
       "sl": 30
     },
-    "w": 20.0
+      "w": 20.0,
+      "ab": "Rock Head",
+      "canEvolve": true,
   },
   "Gloom": {
     "t1": "Grass",
@@ -592,7 +638,8 @@ var POKEDEX_RBY = {
       "sl": 85
     },
     "w": 8.6,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Golbat": {
     "t1": "Poison",
@@ -606,7 +653,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 75
     },
-    "w": 55.0
+      "w": 55.0,
+      "ab": "Inner Focus",
+      "canEvolve": true,
   },
   "Goldeen": {
     "t1": "Water",
@@ -619,7 +668,9 @@ var POKEDEX_RBY = {
       "sp": 63,
       "sl": 50
     },
-    "w": 15.0
+      "w": 15.0,
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Golduck": {
     "t1": "Water",
@@ -632,7 +683,8 @@ var POKEDEX_RBY = {
       "sp": 85,
       "sl": 80
     },
-    "w": 76.6
+      "w": 76.6,
+      "ab": "Cloud Nine",
   },
   "Golem": {
     "t1": "Rock",
@@ -646,7 +698,8 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 55
     },
-    "w": 300.0
+      "w": 300.0,
+      "ab": "Rock Head",
   },
   "Graveler": {
     "t1": "Rock",
@@ -660,7 +713,9 @@ var POKEDEX_RBY = {
       "sp": 35,
       "sl": 45
     },
-    "w": 105.0
+      "w": 105.0,
+      "ab": "Rock Head",
+      "canEvolve": true,
   },
   "Grimer": {
     "t1": "Poison",
@@ -673,7 +728,9 @@ var POKEDEX_RBY = {
       "sp": 25,
       "sl": 40
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Sticky Hold",
+      "canEvolve": true,
   },
   "Growlithe": {
     "t1": "Fire",
@@ -686,7 +743,9 @@ var POKEDEX_RBY = {
       "sp": 60,
       "sl": 50
     },
-    "w": 19.0
+      "w": 19.0,
+      "ab": "Intimidate",
+      "canEvolve": true,
   },
   "Gyarados": {
     "t1": "Water",
@@ -716,7 +775,8 @@ var POKEDEX_RBY = {
       "sl": 115
     },
     "w": 0.1,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Hitmonchan": {
     "t1": "Fighting",
@@ -729,7 +789,8 @@ var POKEDEX_RBY = {
       "sp": 76,
       "sl": 35
     },
-    "w": 50.2
+      "w": 50.2,
+      "ab": "Keen Eye",
   },
   "Hitmonlee": {
     "t1": "Fighting",
@@ -742,7 +803,8 @@ var POKEDEX_RBY = {
       "sp": 87,
       "sl": 35
     },
-    "w": 49.8
+      "w": 49.8,
+      "ab": "Limber",
   },
   "Horsea": {
     "t1": "Water",
@@ -756,7 +818,8 @@ var POKEDEX_RBY = {
       "sl": 70
     },
     "w": 8.0,
-    "ab": "Swift Swim"
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Hypno": {
     "t1": "Psychic",
@@ -769,7 +832,8 @@ var POKEDEX_RBY = {
       "sp": 67,
       "sl": 115
     },
-    "w": 75.6
+      "w": 75.6,
+      "ab": "Insomnia",
   },
   "Ivysaur": {
     "t1": "Grass",
@@ -784,7 +848,8 @@ var POKEDEX_RBY = {
       "sl": 80
     },
     "w": 13.0,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Jigglypuff": {
     "t1": "Normal",
@@ -797,7 +862,9 @@ var POKEDEX_RBY = {
       "sp": 20,
       "sl": 25
     },
-    "w": 5.5
+      "w": 5.5,
+      "ab": "Cute Charm",
+      "canEvolve": true,
   },
   "Jolteon": {
     "t1": "Electric",
@@ -811,7 +878,7 @@ var POKEDEX_RBY = {
       "sl": 110
     },
     "w": 24.5,
-    "ab": "Volt Abdsorb"
+    "ab": "Volt Absorb"
   },
   "Jynx": {
     "t1": "Ice",
@@ -825,7 +892,8 @@ var POKEDEX_RBY = {
       "sp": 95,
       "sl": 95
     },
-    "w": 40.6
+      "w": 40.6,
+      "ab": "Oblivious",
   },
   "Kabuto": {
     "t1": "Rock",
@@ -839,7 +907,9 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 45
     },
-    "w": 11.5
+      "w": 11.5,
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Kabutops": {
     "t1": "Rock",
@@ -853,7 +923,8 @@ var POKEDEX_RBY = {
       "sp": 80,
       "sl": 70
     },
-    "w": 40.5
+      "w": 40.5,
+      "ab": "Swift Swim",
   },
   "Kadabra": {
     "t1": "Psychic",
@@ -866,7 +937,9 @@ var POKEDEX_RBY = {
       "sp": 105,
       "sl": 120
     },
-    "w": 56.5
+      "w": 56.5,
+      "ab": "Synchronize",
+      "canEvolve": true,
   },
   "Kakuna": {
     "t1": "Bug",
@@ -881,7 +954,8 @@ var POKEDEX_RBY = {
       "sl": 25
     },
     "w": 10.0,
-    "ab": "Shed Skin"
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Kangaskhan": {
     "t1": "Normal",
@@ -894,7 +968,8 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 40
     },
-    "w": 80.0
+      "w": 80.0,
+      "ab": "Early Bird",
   },
   "Kingler": {
     "t1": "Water",
@@ -907,7 +982,8 @@ var POKEDEX_RBY = {
       "sp": 75,
       "sl": 50
     },
-    "w": 60.0
+      "w": 60.0,
+      "ab": "Swift Swim",
   },
   "Koffing": {
     "t1": "Poison",
@@ -921,7 +997,8 @@ var POKEDEX_RBY = {
       "sl": 60
     },
     "w": 1.0,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Krabby": {
     "t1": "Water",
@@ -934,7 +1011,9 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 25
     },
-    "w": 6.5
+      "w": 6.5,
+      "ab": "Hyper Cutter",
+      "canEvolve": true,
   },
   "Lapras": {
     "t1": "Water",
@@ -962,7 +1041,9 @@ var POKEDEX_RBY = {
       "sp": 30,
       "sl": 60
     },
-    "w": 65.5
+      "w": 65.5,
+      "ab": "Own Tempo",
+      "canEvolve": true,
   },
   "Machamp": {
     "t1": "Fighting",
@@ -990,7 +1071,8 @@ var POKEDEX_RBY = {
       "sl": 50
     },
     "w": 70.5,
-    "ab": "Guts"
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Machop": {
     "t1": "Fighting",
@@ -1004,7 +1086,8 @@ var POKEDEX_RBY = {
       "sl": 35
     },
     "w": 19.5,
-    "ab": "Guts"
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Magikarp": {
     "t1": "Water",
@@ -1018,7 +1101,8 @@ var POKEDEX_RBY = {
       "sl": 20
     },
     "w": 10.0,
-    "ab": "Swift Swim"
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Magmar": {
     "t1": "Fire",
@@ -1031,7 +1115,9 @@ var POKEDEX_RBY = {
       "sp": 93,
       "sl": 85
     },
-    "w": 44.5
+      "w": 44.5,
+      "ab": "Flame Body",
+      "canEvolve": true,
   },
   "Magnemite": {
     "t1": "Electric",
@@ -1044,7 +1130,9 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 95
     },
-    "w": 6.0
+      "w": 6.0,
+      "ab": "Magnet Pull",
+      "canEvolve": true,
   },
   "Magneton": {
     "t1": "Electric",
@@ -1057,7 +1145,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 120
     },
-    "w": 60.0
+      "w": 60.0,
+      "ab": "Magnet Pull",
+      "canEvolve": true,
   },
   "Mankey": {
     "t1": "Fighting",
@@ -1070,7 +1160,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 35
     },
-    "w": 28.0
+      "w": 28.0,
+      "ab": "Vital Spirit",
+      "canEvolve": true,
   },
   "Marowak": {
     "t1": "Ground",
@@ -1083,7 +1175,8 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 50
     },
-    "w": 45.0
+      "w": 45.0,
+      "ab": "Lightning Rod",
   },
   "Meowth": {
     "t1": "Normal",
@@ -1096,7 +1189,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 40
     },
-    "w": 4.2
+      "w": 4.2,
+      "ab": "Pickup",
+      "canEvolve": true,
   },
   "Metapod": {
     "t1": "Bug",
@@ -1110,7 +1205,8 @@ var POKEDEX_RBY = {
       "sl": 25
     },
     "w": 9.9,
-    "ab": "Shed Skin"
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Mew": {
     "t1": "Psychic",
@@ -1137,7 +1233,8 @@ var POKEDEX_RBY = {
       "sp": 130,
       "sl": 154
     },
-    "w": 122.0
+      "w": 122.0,
+      "ab": "Pressure",
   },
   "Moltres": {
     "t1": "Fire",
@@ -1151,7 +1248,8 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 125
     },
-    "w": 60.0
+      "w": 60.0,
+      "ab": "Pressure",
   },
   "Mr. Mime": {
     "t1": "Psychic",
@@ -1178,7 +1276,8 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 65
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Sticky Hold",
   },
   "Nidoking": {
     "t1": "Poison",
@@ -1192,7 +1291,8 @@ var POKEDEX_RBY = {
       "sp": 85,
       "sl": 75
     },
-    "w": 62.0
+      "w": 62.0,
+      "ab": "Poison Point",
   },
   "Nidoqueen": {
     "t1": "Poison",
@@ -1206,7 +1306,8 @@ var POKEDEX_RBY = {
       "sp": 76,
       "sl": 75
     },
-    "w": 60.0
+      "w": 60.0,
+      "ab": "Poison Point",
   },
   "Nidoran-F": {
     "t1": "Poison",
@@ -1219,7 +1320,9 @@ var POKEDEX_RBY = {
       "sp": 41,
       "sl": 40
     },
-    "w": 7.0
+      "w": 7.0,
+      "ab": "Poison Point",
+      "canEvolve": true,
   },
   "Nidoran-M": {
     "t1": "Poison",
@@ -1232,7 +1335,9 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 40
     },
-    "w": 9.0
+      "w": 9.0,
+      "ab": "Poison Point",
+      "canEvolve": true,
   },
   "Nidorina": {
     "t1": "Poison",
@@ -1245,7 +1350,9 @@ var POKEDEX_RBY = {
       "sp": 56,
       "sl": 55
     },
-    "w": 20.0
+      "w": 20.0,
+      "ab": "Poison Point",
+      "canEvolve": true,
   },
   "Nidorino": {
     "t1": "Poison",
@@ -1258,7 +1365,9 @@ var POKEDEX_RBY = {
       "sp": 65,
       "sl": 55
     },
-    "w": 19.5
+      "w": 19.5,
+      "ab": "Poison Point",
+      "canEvolve": true,
   },
   "Ninetales": {
     "t1": "Fire",
@@ -1287,7 +1396,8 @@ var POKEDEX_RBY = {
       "sl": 75
     },
     "w": 5.4,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Omanyte": {
     "t1": "Rock",
@@ -1301,7 +1411,9 @@ var POKEDEX_RBY = {
       "sp": 35,
       "sl": 90
     },
-    "w": 7.5
+      "w": 7.5,
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Omastar": {
     "t1": "Rock",
@@ -1315,7 +1427,8 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 115
     },
-    "w": 35.0
+      "w": 35.0,
+      "ab": "Swift Swim",
   },
   "Onix": {
     "t1": "Rock",
@@ -1329,7 +1442,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 30
     },
-    "w": 210.0
+      "w": 210.0,
+      "ab": "Rock Head",
+      "canEvolve": true,
   },
   "Paras": {
     "t1": "Bug",
@@ -1343,7 +1458,9 @@ var POKEDEX_RBY = {
       "sp": 25,
       "sl": 55
     },
-    "w": 5.4
+      "w": 5.4,
+      "ab": "Effect Spore",
+      "canEvolve": true,
   },
   "Parasect": {
     "t1": "Bug",
@@ -1357,7 +1474,8 @@ var POKEDEX_RBY = {
       "sp": 30,
       "sl": 80
     },
-    "w": 29.5
+      "w": 29.5,
+      "ab": "Effect Spore",
   },
   "Persian": {
     "t1": "Normal",
@@ -1370,7 +1488,8 @@ var POKEDEX_RBY = {
       "sp": 115,
       "sl": 65
     },
-    "w": 32.0
+      "w": 32.0,
+      "ab": "Limber",
   },
   "Pidgeot": {
     "t1": "Normal",
@@ -1384,7 +1503,8 @@ var POKEDEX_RBY = {
       "sp": 91,
       "sl": 70
     },
-    "w": 39.5
+      "w": 39.5,
+      "ab": "Keen Eye",
   },
   "Pidgeotto": {
     "t1": "Normal",
@@ -1398,7 +1518,9 @@ var POKEDEX_RBY = {
       "sp": 71,
       "sl": 50
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Keen Eye",
+      "canEvolve": true,
   },
   "Pidgey": {
     "t1": "Normal",
@@ -1412,7 +1534,9 @@ var POKEDEX_RBY = {
       "sp": 56,
       "sl": 35
     },
-    "w": 1.8
+      "w": 1.8,
+      "ab": "Keen Eye",
+      "canEvolve": true,
   },
   "Pikachu": {
     "t1": "Electric",
@@ -1425,7 +1549,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 50
     },
-    "w": 6.0
+      "w": 6.0,
+      "ab": "Static",
+      "canEvolve": true,
   },
   "Pinsir": {
     "t1": "Bug",
@@ -1452,7 +1578,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 40
     },
-    "w": 12.4
+      "w": 12.4,
+      "ab": "Water Absorb",
+      "canEvolve": true,
   },
   "Poliwhirl": {
     "t1": "Water",
@@ -1465,7 +1593,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 50
     },
-    "w": 20.0
+      "w": 20.0,
+      "ab": "Water Absorb",
+      "canEvolve": true,
   },
   "Poliwrath": {
     "t1": "Water",
@@ -1479,7 +1609,8 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 70
     },
-    "w": 54.0
+      "w": 54.0,
+      "ab": "Water Absorb",
   },
   "Ponyta": {
     "t1": "Fire",
@@ -1492,7 +1623,9 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 65
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Flash Fire",
+      "canEvolve": true,
   },
   "Porygon": {
     "t1": "Normal",
@@ -1505,7 +1638,9 @@ var POKEDEX_RBY = {
       "sp": 40,
       "sl": 75
     },
-    "w": 36.5
+      "w": 36.5,
+      "ab": "Trace",
+      "canEvolve": true,
   },
   "Primeape": {
     "t1": "Fighting",
@@ -1518,7 +1653,8 @@ var POKEDEX_RBY = {
       "sp": 95,
       "sl": 60
     },
-    "w": 32.0
+      "w": 32.0,
+      "ab": "Vital Spirit",
   },
   "Psyduck": {
     "t1": "Water",
@@ -1531,7 +1667,9 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 50
     },
-    "w": 19.6
+      "w": 19.6,
+      "ab": "Cloud Nine",
+      "canEvolve": true,
   },
   "Raichu": {
     "t1": "Electric",
@@ -1544,7 +1682,8 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 90
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Static",
   },
   "Rapidash": {
     "t1": "Fire",
@@ -1557,7 +1696,8 @@ var POKEDEX_RBY = {
       "sp": 105,
       "sl": 80
     },
-    "w": 95.0
+      "w": 95.0,
+      "ab": "Flash Fire",
   },
   "Raticate": {
     "t1": "Normal",
@@ -1570,7 +1710,8 @@ var POKEDEX_RBY = {
       "sp": 97,
       "sl": 50
     },
-    "w": 18.5
+      "w": 18.5,
+      "ab": "Guts",
   },
   "Rattata": {
     "t1": "Normal",
@@ -1583,7 +1724,9 @@ var POKEDEX_RBY = {
       "sp": 72,
       "sl": 25
     },
-    "w": 3.5
+      "w": 3.5,
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Rhydon": {
     "t1": "Ground",
@@ -1597,7 +1740,9 @@ var POKEDEX_RBY = {
       "sp": 40,
       "sl": 45
     },
-    "w": 120.0
+      "w": 120.0,
+      "ab": "Lightning Rod",
+      "canEvolve": true,
   },
   "Rhyhorn": {
     "t1": "Ground",
@@ -1611,7 +1756,9 @@ var POKEDEX_RBY = {
       "sp": 25,
       "sl": 30
     },
-    "w": 115.0
+      "w": 115.0,
+      "ab": "Lightning Rod",
+      "canEvolve": true,
   },
   "Sandshrew": {
     "t1": "Ground",
@@ -1625,7 +1772,8 @@ var POKEDEX_RBY = {
       "sl": 30
     },
     "w": 12.0,
-    "ab": "Sand Veil"
+      "ab": "Sand Veil",
+      "canEvolve": true,
   },
   "Sandslash": {
     "t1": "Ground",
@@ -1654,7 +1802,8 @@ var POKEDEX_RBY = {
       "sl": 55
     },
     "w": 56.0,
-    "ab": "Swarm"
+      "ab": "Swarm",
+      "canEvolve": true,
   },
   "Seadra": {
     "t1": "Water",
@@ -1667,7 +1816,9 @@ var POKEDEX_RBY = {
       "sp": 85,
       "sl": 95
     },
-    "w": 25.0
+      "w": 25.0,
+      "ab": "Poison Point",
+      "canEvolve": true,
   },
   "Seaking": {
     "t1": "Water",
@@ -1680,7 +1831,8 @@ var POKEDEX_RBY = {
       "sp": 68,
       "sl": 80
     },
-    "w": 39.0
+      "w": 39.0,
+      "ab": "Swift Swim",
   },
   "Seel": {
     "t1": "Water",
@@ -1694,7 +1846,8 @@ var POKEDEX_RBY = {
       "sl": 70
     },
     "w": 90.0,
-    "ab": "Thick Fat"
+      "ab": "Thick Fat",
+      "canEvolve": true,
   },
   "Shellder": {
     "t1": "Water",
@@ -1708,7 +1861,8 @@ var POKEDEX_RBY = {
       "sl": 45
     },
     "w": 4.0,
-    "ab": "Shell Armor"
+      "ab": "Shell Armor",
+      "canEvolve": true,
   },
   "Slowbro": {
     "t1": "Water",
@@ -1722,7 +1876,8 @@ var POKEDEX_RBY = {
       "sp": 30,
       "sl": 80
     },
-    "w": 78.5
+      "w": 78.5,
+      "ab": "Oblivious",
   },
   "Slowpoke": {
     "t1": "Water",
@@ -1736,7 +1891,9 @@ var POKEDEX_RBY = {
       "sp": 15,
       "sl": 40
     },
-    "w": 36.0
+      "w": 36.0,
+      "ab": "Oblivious",
+      "canEvolve": true,
   },
   "Snorlax": {
     "t1": "Normal",
@@ -1750,7 +1907,7 @@ var POKEDEX_RBY = {
       "sl": 65
     },
       "w": 460.0,
-      "ab": "Gluttony"
+      "ab": "Thick Fat"
   },
   "Spearow": {
     "t1": "Normal",
@@ -1764,7 +1921,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 31
     },
-    "w": 2.0
+      "w": 2.0,
+      "ab": "Keen Eye",
+      "canEvolve": true,
   },
   "Squirtle": {
     "t1": "Water",
@@ -1778,7 +1937,8 @@ var POKEDEX_RBY = {
       "sl": 50
     },
     "w": 9.0,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Starmie": {
     "t1": "Water",
@@ -1792,7 +1952,8 @@ var POKEDEX_RBY = {
       "sp": 115,
       "sl": 100
     },
-    "w": 80.0
+      "w": 80.0,
+      "ab": "Natural Cure",
   },
   "Staryu": {
     "t1": "Water",
@@ -1805,7 +1966,9 @@ var POKEDEX_RBY = {
       "sp": 85,
       "sl": 70
     },
-    "w": 34.5
+      "w": 34.5,
+      "ab": "Natural Cure",
+      "canEvolve": true,
   },
   "Tangela": {
     "t1": "Grass",
@@ -1819,7 +1982,8 @@ var POKEDEX_RBY = {
       "sl": 100
     },
     "w": 35.0,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Tauros": {
     "t1": "Normal",
@@ -1847,7 +2011,9 @@ var POKEDEX_RBY = {
       "sp": 70,
       "sl": 100
     },
-    "w": 45.5
+      "w": 45.5,
+      "ab": "Liquid Ooze",
+      "canEvolve": true,
   },
   "Tentacruel": {
     "t1": "Water",
@@ -1861,7 +2027,8 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 120
     },
-    "w": 55.0
+      "w": 55.0,
+      "ab": "Liquid Ooze",
   },
   "Vaporeon": {
     "t1": "Water",
@@ -1889,7 +2056,8 @@ var POKEDEX_RBY = {
       "sp": 90,
       "sl": 90
     },
-    "w": 12.5
+      "w": 12.5,
+      "ab": "Shield Dust",
   },
   "Venonat": {
     "t1": "Bug",
@@ -1903,7 +2071,9 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 40
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Shield Dust",
+      "canEvolve": true,
   },
   "Venusaur": {
     "t1": "Grass",
@@ -1961,7 +2131,9 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 55
     },
-    "w": 10.4
+      "w": 10.4,
+      "ab": "Soundproof",
+      "canEvolve": true,
   },
   "Vulpix": {
     "t1": "Fire",
@@ -1975,7 +2147,8 @@ var POKEDEX_RBY = {
       "sl": 65
     },
     "w": 9.9,
-    "ab": "Flash Fire"
+      "ab": "Flash Fire",
+      "canEvolve": true,
   },
   "Wartortle": {
     "t1": "Water",
@@ -1989,7 +2162,8 @@ var POKEDEX_RBY = {
       "sl": 65
     },
     "w": 22.5,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Weedle": {
     "t1": "Bug",
@@ -2003,7 +2177,9 @@ var POKEDEX_RBY = {
       "sp": 50,
       "sl": 20
     },
-    "w": 3.2
+      "w": 3.2,
+      "ab": "Shield Dust",
+      "canEvolve": true,
   },
   "Weepinbell": {
     "t1": "Grass",
@@ -2018,7 +2194,8 @@ var POKEDEX_RBY = {
       "sl": 85
     },
     "w": 6.4,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Weezing": {
     "t1": "Poison",
@@ -2045,7 +2222,8 @@ var POKEDEX_RBY = {
       "sp": 45,
       "sl": 50
     },
-    "w": 12.0
+      "w": 12.0,
+      "ab": "Cute Charm",
   },
   "Zapdos": {
     "t1": "Electric",
@@ -2059,7 +2237,8 @@ var POKEDEX_RBY = {
       "sp": 100,
       "sl": 125
     },
-    "w": 52.6
+      "w": 52.6,
+      "ab": "Pressure",
   },
   "Zubat": {
     "t1": "Poison",
@@ -2073,7 +2252,9 @@ var POKEDEX_RBY = {
       "sp": 55,
       "sl": 40
     },
-    "w": 7.5
+      "w": 7.5,
+      "ab": "Inner Focus",
+      "canEvolve": true,
   }
 };
 
@@ -2088,9 +2269,11 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "df": 55,
       "sa": 40,
       "sd": 55,
-      "sp": 85
+        "sp": 85,
+        "canEvolve": true,
     },
-    "w": 11.5
+      "w": 11.5,
+      "ab": "Pickup",
   },
   "Ampharos": {
     "t1": "Electric",
@@ -2102,7 +2285,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 90,
       "sp": 55
     },
-    "w": 61.5
+      "w": 61.5,
+      "ab": "Static",
   },
   "Ariados": {
     "t1": "Bug",
@@ -2115,7 +2299,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 60,
       "sp": 40
     },
-    "w": 33.5
+      "w": 33.5,
+      "ab": "Swarm",
   },
   "Azumarill": {
     "t1": "Water",
@@ -2127,7 +2312,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 80,
       "sp": 50
     },
-    "w": 28.5
+      "w": 28.5,
+      "ab": "Huge Power",
   },
   "Bayleef": {
     "t1": "Grass",
@@ -2140,7 +2326,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 60
     },
     "w": 15.8,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Bellossom": {
     "t1": "Grass",
@@ -2165,7 +2352,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 135,
       "sp": 55
     },
-    "w": 46.8
+      "w": 46.8,
+      "ab": "Natural Cure",
   },
   "Celebi": {
     "t1": "Psychic",
@@ -2192,7 +2380,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 45
     },
     "w": 6.4,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Chinchou": {
     "t1": "Water",
@@ -2205,7 +2394,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 56,
       "sp": 67
     },
-    "w": 12.0
+      "w": 12.0,
+      "ab": "Volt Absorb",
+      "canEvolve": true,
   },
   "Cleffa": {
     "t1": "Normal",
@@ -2217,7 +2408,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 55,
       "sp": 15
     },
-    "w": 3.0
+      "w": 3.0,
+      "ab": "Cute Charm",
+      "canEvolve": true,
   },
   "Corsola": {
     "t1": "Water",
@@ -2230,7 +2423,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 85,
       "sp": 35
     },
-    "w": 5.0
+      "w": 5.0,
+      "ab": "Natural Cure",
   },
   "Crobat": {
     "t1": "Poison",
@@ -2243,7 +2437,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 80,
       "sp": 130
     },
-    "w": 75.0
+      "w": 75.0,
+      "ab": "Inner Focus",
   },
   "Croconaw": {
     "t1": "Water",
@@ -2256,7 +2451,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 58
     },
     "w": 25.0,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Cyndaquil": {
     "t1": "Fire",
@@ -2269,7 +2465,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 65
     },
     "w": 7.9,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Delibird": {
     "t1": "Ice",
@@ -2282,7 +2479,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 75
     },
-    "w": 16.0
+      "w": 16.0,
+      "ab": "Vital Spirit",
   },
   "Donphan": {
     "t1": "Ground",
@@ -2294,7 +2492,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 60,
       "sp": 50
     },
-    "w": 120.0
+      "w": 120.0,
+      "ab": "Sturdy",
   },
   "Dunsparce": {
     "t1": "Normal",
@@ -2306,7 +2505,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 45
     },
-    "w": 14.0
+      "w": 14.0,
+      "ab": "Serene Grace",
   },
   "Elekid": {
     "t1": "Electric",
@@ -2318,7 +2518,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 55,
       "sp": 95
     },
-    "w": 23.5
+      "w": 23.5,
+      "ab": "Static",
+      "canEvolve": true,
   },
   "Entei": {
     "t1": "Fire",
@@ -2330,7 +2532,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 75,
       "sp": 100
     },
-    "w": 198.0
+      "w": 198.0,
+      "ab": "Pressure",
   },
   "Espeon": {
     "t1": "Psychic",
@@ -2342,7 +2545,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 95,
       "sp": 110
     },
-    "w": 26.5
+      "w": 26.5,
+      "ab": "Synchronize",
   },
   "Feraligatr": {
     "t1": "Water",
@@ -2367,7 +2571,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 60,
       "sp": 45
     },
-    "w": 13.3
+      "w": 13.3,
+      "ab": "Static",
+      "canEvolve": true,
   },
   "Forretress": {
     "t1": "Bug",
@@ -2380,7 +2586,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 60,
       "sp": 40
     },
-    "w": 125.8
+      "w": 125.8,
+      "ab": "Sturdy",
   },
   "Furret": {
     "t1": "Normal",
@@ -2392,7 +2599,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 55,
       "sp": 90
     },
-    "w": 32.5
+      "w": 32.5,
+      "ab": "Keen Eye",
   },
   "Girafarig": {
     "t1": "Normal",
@@ -2405,7 +2613,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 85
     },
-    "w": 41.5
+      "w": 41.5,
+      "ab": "Early Bird",
   },
   "Gligar": {
     "t1": "Ground",
@@ -2418,7 +2627,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 85
     },
-    "w": 64.8
+      "w": 64.8,
+      "ab": "Hyper Cutter",
+      "canEvolve": true,
   },
   "Granbull": {
     "t1": "Normal",
@@ -2444,7 +2655,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 95,
       "sp": 85
     },
-    "w": 54.0
+      "w": 54.0,
+      "ab": "Guts",
   },
   "Hitmontop": {
     "t1": "Fighting",
@@ -2470,7 +2682,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 154,
       "sp": 90
     },
-    "w": 199.0
+      "w": 199.0,
+      "ab": "Pressure",
   },
   "Hoothoot": {
     "t1": "Normal",
@@ -2483,7 +2696,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 56,
       "sp": 50
     },
-    "w": 21.2
+      "w": 21.2,
+      "ab": "Insomnia",
+      "canEvolve": true,
   },
   "Hoppip": {
     "t1": "Grass",
@@ -2497,7 +2712,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 50
     },
     "w": 0.5,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Houndoom": {
     "t1": "Dark",
@@ -2510,7 +2726,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 80,
       "sp": 95
     },
-    "w": 35.0
+      "w": 35.0,
+      "ab": "Flash Fire",
   },
   "Houndour": {
     "t1": "Dark",
@@ -2523,7 +2740,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 50,
       "sp": 65
     },
-    "w": 10.8
+      "w": 10.8,
+      "ab": "Flash Fire",
+      "canEvolve": true,
   },
   "Igglybuff": {
     "t1": "Normal",
@@ -2535,7 +2754,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 20,
       "sp": 15
     },
-    "w": 1.0
+      "w": 1.0,
+      "ab": "Cute Charm",
+      "canEvolve": true,
   },
   "Jumpluff": {
     "t1": "Grass",
@@ -2576,7 +2797,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 76,
       "sp": 67
     },
-    "w": 22.5
+      "w": 22.5,
+      "ab": "Volt Absorb",
   },
   "Larvitar": {
     "t1": "Rock",
@@ -2590,7 +2812,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 41
     },
     "w": 72.0,
-    "ab": "Guts"
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Ledian": {
     "t1": "Bug",
@@ -2603,7 +2826,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 110,
       "sp": 85
     },
-    "w": 35.6
+      "w": 35.6,
+      "ab": "Early Bird",
   },
   "Ledyba": {
     "t1": "Bug",
@@ -2616,7 +2840,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 80,
       "sp": 55
     },
-    "w": 10.8
+      "w": 10.8,
+      "ab": "Early Bird",
+      "canEvolve": true,
   },
   "Lugia": {
     "t1": "Psychic",
@@ -2629,7 +2855,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 154,
       "sp": 110
     },
-    "w": 216.0
+      "w": 216.0,
+      "ab": "Pressure",
   },
   "Magby": {
     "t1": "Fire",
@@ -2641,7 +2868,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 55,
       "sp": 83
     },
-    "w": 21.4
+      "w": 21.4,
+      "ab": "Flame Body",
+      "canEvolve": true,
   },
   "Magcargo": {
     "t1": "Fire",
@@ -2654,7 +2883,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 80,
       "sp": 30
     },
-    "w": 55.0
+      "w": 55.0,
+      "ab": "Flame Body",
   },
   "Mantine": {
     "t1": "Water",
@@ -2667,7 +2897,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 140,
       "sp": 70
     },
-    "w": 220.0
+      "w": 220.0,
+      "ab": "Water Absorb",
   },
   "Mareep": {
     "t1": "Electric",
@@ -2679,7 +2910,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 35
     },
-    "w": 7.8
+      "w": 7.8,
+      "ab": "Static",
+      "canEvolve": true,
   },
   "Marill": {
     "t1": "Water",
@@ -2691,7 +2924,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 50,
       "sp": 40
     },
-    "w": 8.5
+      "w": 8.5,
+      "ab": "Huge Power",
+      "canEvolve": true,
   },
   "Meganium": {
     "t1": "Grass",
@@ -2730,7 +2965,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 85
     },
     "w": 1.0,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Murkrow": {
     "t1": "Dark",
@@ -2743,7 +2979,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 42,
       "sp": 91
     },
-    "w": 2.1
+      "w": 2.1,
+      "ab": "Insomnia",
+      "canEvolve": true,
   },
   "Natu": {
     "t1": "Psychic",
@@ -2756,7 +2994,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 70
     },
-    "w": 2.0
+      "w": 2.0,
+      "ab": "Synchronize",
+      "canEvolve": true,
   },
   "Noctowl": {
     "t1": "Normal",
@@ -2769,7 +3009,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 96,
       "sp": 70
     },
-    "w": 40.8
+      "w": 40.8,
+      "ab": "Insomnia",
   },
   "Octillery": {
     "t1": "Water",
@@ -2781,7 +3022,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 75,
       "sp": 45
     },
-    "w": 28.5
+      "w": 28.5,
+      "ab": "Suction Cups",
   },
   "Phanpy": {
     "t1": "Ground",
@@ -2793,7 +3035,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 40,
       "sp": 40
     },
-    "w": 33.5
+      "w": 33.5,
+      "ab": "Pickup",
+      "canEvolve": true,
   },
   "Pichu": {
     "t1": "Electric",
@@ -2805,7 +3049,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 35,
       "sp": 60
     },
-    "w": 2.0
+      "w": 2.0,
+      "ab": "Static",
+      "canEvolve": true,
   },
   "Piloswine": {
     "t1": "Ice",
@@ -2818,7 +3064,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 60,
       "sp": 50
     },
-    "w": 55.8
+      "w": 55.8,
+      "ab": "Oblivious",
+      "canEvolve": true,
   },
   "Pineco": {
     "t1": "Bug",
@@ -2830,7 +3078,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 35,
       "sp": 15
     },
-    "w": 7.2
+      "w": 7.2,
+      "ab": "Sturdy",
+      "canEvolve": true,
   },
   "Politoed": {
     "t1": "Water",
@@ -2842,7 +3092,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 100,
       "sp": 70
     },
-    "w": 33.9
+      "w": 33.9,
+      "ab": "Water Absorb",
   },
   "Porygon2": {
     "t1": "Normal",
@@ -2854,7 +3105,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 95,
       "sp": 60
     },
-    "w": 32.5
+      "w": 32.5,
+      "ab": "Trace",
+      "canEvolve": true,
   },
   "Pupitar": {
     "t1": "Rock",
@@ -2868,7 +3121,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 51
     },
     "w": 152.0,
-    "ab": "Shed Skin"
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Quagsire": {
     "t1": "Water",
@@ -2881,7 +3135,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 35
     },
-    "w": 75.0
+      "w": 75.0,
+      "ab": "Water Absorb",
   },
   "Quilava": {
     "t1": "Fire",
@@ -2894,7 +3149,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 80
     },
     "w": 19.0,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Qwilfish": {
     "t1": "Water",
@@ -2907,7 +3163,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 55,
       "sp": 85
     },
-    "w": 3.9
+      "w": 3.9,
+      "ab": "Swift Swim",
   },
   "Raikou": {
     "t1": "Electric",
@@ -2919,7 +3176,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 100,
       "sp": 115
     },
-    "w": 178.0
+      "w": 178.0,
+      "ab": "Pressure",
   },
   "Remoraid": {
     "t1": "Water",
@@ -2931,7 +3189,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 35,
       "sp": 65
     },
-    "w": 12.0
+      "w": 12.0,
+      "ab": "Hustle",
+      "canEvolve": true,
   },
   "Scizor": {
     "t1": "Bug",
@@ -2957,7 +3217,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 20
     },
-    "w": 6.0
+      "w": 6.0,
+      "ab": "Keen Eye",
+      "canEvolve": true,
   },
   "Shuckle": {
     "t1": "Bug",
@@ -2970,7 +3232,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 230,
       "sp": 5
     },
-    "w": 20.5
+      "w": 20.5,
+      "ab": "Sturdy",
   },
   "Skarmory": {
     "t1": "Steel",
@@ -2983,7 +3246,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 70,
       "sp": 70
     },
-    "w": 50.5
+      "w": 50.5,
+      "ab": "Sturdy",
   },
   "Skiploom": {
     "t1": "Grass",
@@ -2997,7 +3261,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 80
     },
     "w": 1.0,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Slowking": {
     "t1": "Water",
@@ -3010,7 +3275,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 110,
       "sp": 30
     },
-    "w": 79.5
+      "w": 79.5,
+      "ab": "Oblivious",
   },
   "Slugma": {
     "t1": "Fire",
@@ -3022,7 +3288,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 40,
       "sp": 20
     },
-    "w": 35.0
+      "w": 35.0,
+      "ab": "Flame Body",
+      "canEvolve": true,
   },
   "Smeargle": {
     "t1": "Normal",
@@ -3034,7 +3302,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 75
     },
-    "w": 58.0
+      "w": 58.0,
+      "ab": "Own Tempo",
   },
   "Smoochum": {
     "t1": "Ice",
@@ -3047,7 +3316,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 65
     },
-    "w": 6.0
+      "w": 6.0,
+      "ab": "Oblivious",
+      "canEvolve": true,
   },
   "Sneasel": {
     "t1": "Dark",
@@ -3060,7 +3331,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 75,
       "sp": 115
     },
-    "w": 28.0
+      "w": 28.0,
+      "ab": "Inner Focus",
+      "canEvolve": true,
   },
   "Snubbull": {
     "t1": "Normal",
@@ -3072,7 +3345,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 40,
       "sp": 30
     },
-    "w": 7.8
+      "w": 7.8,
+      "ab": "Intimidate",
+      "canEvolve": true,
   },
   "Spinarak": {
     "t1": "Bug",
@@ -3085,7 +3360,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 40,
       "sp": 30
     },
-    "w": 8.5
+      "w": 8.5,
+      "ab": "Insomnia",
+      "canEvolve": true,
   },
   "Stantler": {
     "t1": "Normal",
@@ -3111,7 +3388,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 30
     },
-    "w": 400.0
+      "w": 400.0,
+      "ab": "Sturdy",
   },
   "Sudowoodo": {
     "t1": "Rock",
@@ -3123,7 +3401,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 30
     },
-    "w": 38.0
+      "w": 38.0,
+      "ab": "Sturdy",
   },
   "Suicune": {
     "t1": "Water",
@@ -3135,7 +3414,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 115,
       "sp": 85
     },
-    "w": 187.0
+      "w": 187.0,
+      "ab": "Pressure",
   },
   "Sunflora": {
     "t1": "Grass",
@@ -3161,7 +3441,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 30
     },
     "w": 1.8,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Swinub": {
     "t1": "Ice",
@@ -3174,7 +3455,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 30,
       "sp": 50
     },
-    "w": 6.5
+      "w": 6.5,
+      "ab": "Oblivious",
+      "canEvolve": true,
   },
   "Teddiursa": {
     "t1": "Normal",
@@ -3186,7 +3469,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 50,
       "sp": 40
     },
-    "w": 8.8
+      "w": 8.8,
+      "ab": "Pickup",
+      "canEvolve": true,
   },
   "Togepi": {
     "t1": "Normal",
@@ -3198,7 +3483,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 65,
       "sp": 20
     },
-    "w": 1.5
+      "w": 1.5,
+      "ab": "Serene Grace",
+      "canEvolve": true,
   },
   "Togetic": {
     "t1": "Normal",
@@ -3211,7 +3498,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 105,
       "sp": 40
     },
-    "w": 3.2
+      "w": 3.2,
+      "ab": "Serene Grace",
+      "canEvolve": true,
   },
   "Totodile": {
     "t1": "Water",
@@ -3224,7 +3513,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 43
     },
     "w": 9.5,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Typhlosion": {
     "t1": "Fire",
@@ -3264,7 +3554,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sp": 35
     },
     "w": 21.0,
-    "ab": "Guts"
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Umbreon": {
     "t1": "Dark",
@@ -3276,7 +3567,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 130,
       "sp": 65
     },
-    "w": 27.0
+      "w": 27.0,
+      "ab": "Synchronize",
   },
   "Unown": {
     "t1": "Psychic",
@@ -3314,7 +3606,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 58,
       "sp": 33
     },
-    "w": 28.5
+      "w": 28.5,
+      "ab": "Shadow Tag",
   },
   "Wooper": {
     "t1": "Water",
@@ -3327,7 +3620,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 25,
       "sp": 15
     },
-    "w": 8.5
+      "w": 8.5,
+      "ab": "Water Absorb",
+      "canEvolve": true,
   },
   "Xatu": {
     "t1": "Psychic",
@@ -3340,7 +3635,8 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 70,
       "sp": 95
     },
-    "w": 15.0
+      "w": 15.0,
+      "ab": "Synchronize",
   },
   "Yanma": {
     "t1": "Bug",
@@ -3353,7 +3649,9 @@ var POKEDEX_GSC = $.extend(true, {}, POKEDEX_RBY, {
       "sd": 45,
       "sp": 95
     },
-    "w": 38.0
+      "w": 38.0,
+      "ab": "Speed Boost",
+      "canEvolve": true,
   }
 });
 
@@ -3368,7 +3666,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 75
     },
-    "w": 47.0
+        "w": 47.0,
+        "ab": "Pressure",
   },
   "Aggron": {
     "t1": "Steel",
@@ -3381,7 +3680,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 50
     },
-    "w": 360.0
+      "w": 360.0,
+      "ab": "Sturdy",
   },
   "Altaria": {
     "t1": "Dragon",
@@ -3394,7 +3694,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 105,
       "sp": 80
     },
-    "w": 20.6
+      "w": 20.6,
+      "ab": "Natural Cure",
   },
   "Anorith": {
     "t1": "Rock",
@@ -3408,7 +3709,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 75
     },
     "w": 12.5,
-    "ab": "Battle Armor"
+      "ab": "Battle Armor",
+      "canEvolve": true,
   },
   "Armaldo": {
     "t1": "Rock",
@@ -3435,7 +3737,9 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 40,
       "sp": 30
     },
-    "w": 60.0
+      "w": 60.0,
+      "ab": "Sturdy",
+      "canEvolve": true,
   },
   "Azurill": {
     "t1": "Normal",
@@ -3447,7 +3751,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 40,
       "sp": 20
     },
-    "w": 2.0
+      "w": 2.0,
+      "canEvolve": true,
   },
   "Bagon": {
     "t1": "Dragon",
@@ -3459,7 +3764,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 50
     },
-    "w": 42.1
+      "w": 42.1,
+      "canEvolve": true,
   },
   "Baltoy": {
     "t1": "Ground",
@@ -3473,7 +3779,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 55
     },
     "w": 21.5,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Banette": {
     "t1": "Ghost",
@@ -3485,7 +3792,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 63,
       "sp": 65
     },
-    "w": 12.5
+      "w": 12.5,
+      "ab": "Insomnia",
   },
   "Barboach": {
     "t1": "Water",
@@ -3498,7 +3806,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 41,
       "sp": 60
     },
-    "w": 1.9
+      "w": 1.9,
+      "canEvolve": true,
   },
   "Beautifly": {
     "t1": "Bug",
@@ -3526,7 +3835,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 30
     },
     "w": 95.2,
-    "ab": "Clear Body"
+      "ab": "Clear Body",
+      "canEvolve": true,
   },
   "Blaziken": {
     "t1": "Fire",
@@ -3553,7 +3863,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 70
     },
-    "w": 39.2
+      "w": 39.2,
+      "ab": "Effect Spore",
   },
   "Cacnea": {
     "t1": "Grass",
@@ -3566,7 +3877,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 35
     },
     "w": 51.3,
-    "ab": "Sand Veil"
+      "ab": "Sand Veil",
+      "canEvolve": true,
   },
   "Cacturne": {
     "t1": "Grass",
@@ -3593,7 +3905,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 75,
       "sp": 40
     },
-    "w": 220.0
+      "w": 220.0,
+      "ab": "Magma Armor",
   },
   "Carvanha": {
     "t1": "Water",
@@ -3606,7 +3919,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 20,
       "sp": 65
     },
-    "w": 20.8
+      "w": 20.8,
+      "canEvolve": true,
   },
   "Cascoon": {
     "t1": "Bug",
@@ -3619,7 +3933,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 15
     },
     "w": 11.5,
-    "ab": "Shed Skin"
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Castform": {
     "t1": "Normal",
@@ -3658,7 +3973,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 32
     },
     "w": 52.5,
-    "ab": "Shell Armor"
+      "ab": "Shell Armor",
+      "canEvolve": true,
   },
   "Claydol": {
     "t1": "Ground",
@@ -3686,7 +4002,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 55
     },
     "w": 19.5,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Corphish": {
     "t1": "Water",
@@ -3698,7 +4015,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 35,
       "sp": 35
     },
-    "w": 11.5
+      "w": 11.5,
+      "canEvolve": true,
   },
   "Cradily": {
     "t1": "Rock",
@@ -3711,7 +4029,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 107,
       "sp": 43
     },
-    "w": 60.4
+      "w": 60.4,
+      "ab": "Suction Cups",
   },
   "Crawdaunt": {
     "t1": "Water",
@@ -3724,7 +4043,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 55,
       "sp": 55
     },
-    "w": 32.8
+      "w": 32.8,
+      "ab": "Hyper Cutter",
   },
   "Delcatty": {
     "t1": "Normal",
@@ -3736,7 +4056,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 55,
       "sp": 70
     },
-    "w": 32.6
+      "w": 32.6,
+      "ab": "Cute Charm",
   },
   "Deoxys": {
     "t1": "Psychic",
@@ -3800,7 +4121,9 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 130,
       "sp": 25
     },
-    "w": 30.6
+      "w": 30.6,
+      "ab": "Pressure",
+      "canEvolve": true,
   },
   "Duskull": {
     "t1": "Ghost",
@@ -3813,7 +4136,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 25
     },
     "w": 15.0,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Dustox": {
     "t1": "Bug",
@@ -3826,7 +4150,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 90,
       "sp": 65
     },
-    "w": 31.6
+      "w": 31.6,
+      "ab": "Shield Dust",
   },
   "Electrike": {
     "t1": "Electric",
@@ -3838,7 +4163,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 40,
       "sp": 65
     },
-    "w": 15.2
+      "w": 15.2,
+      "canEvolve": true,
   },
   "Exploud": {
     "t1": "Normal",
@@ -3864,7 +4190,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 80
     },
     "w": 7.4,
-    "ab": "Swift Swim"
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Flygon": {
     "t1": "Ground",
@@ -3890,7 +4217,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 115,
       "sp": 80
     },
-    "w": 48.4
+      "w": 48.4,
+      "ab": "Trace",
   },
   "Glalie": {
     "t1": "Ice",
@@ -3902,7 +4230,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 80,
       "sp": 80
     },
-    "w": 256.5
+      "w": 256.5,
+      "ab": "Inner Focus",
   },
   "Gorebyss": {
     "t1": "Water",
@@ -3941,7 +4270,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 95
     },
     "w": 21.6,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Grumpig": {
     "t1": "Psychic",
@@ -3953,7 +4283,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 110,
       "sp": 80
     },
-    "w": 71.5
+      "w": 71.5,
+      "ab": "Tick Fat",
   },
   "Gulpin": {
     "t1": "Poison",
@@ -3965,7 +4296,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 53,
       "sp": 40
     },
-    "w": 10.3
+      "w": 10.3,
+      "canEvolve": true,
   },
   "Hariyama": {
     "t1": "Fighting",
@@ -3977,7 +4309,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 50
     },
-    "w": 253.8
+      "w": 253.8,
+      "ab": "Guts",
   },
   "Huntail": {
     "t1": "Water",
@@ -4002,7 +4335,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 75,
       "sp": 85
     },
-    "w": 17.7
+      "w": 17.7,
+      "ab": "Oblivious",
   },
   "Jirachi": {
     "t1": "Steel",
@@ -4028,7 +4362,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 120,
       "sp": 40
     },
-    "w": 22.0
+      "w": 22.0,
+      "ab": "Color Change",
   },
   "Kirlia": {
     "t1": "Psychic",
@@ -4040,7 +4375,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 55,
       "sp": 50
     },
-    "w": 20.2
+      "w": 20.2,
+      "canEvolve": true,
   },
   "Kyogre": {
     "t1": "Water",
@@ -4066,7 +4402,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 50,
       "sp": 40
     },
-    "w": 120.0
+      "w": 120.0,
+      "canEvolve": true,
   },
   "Latias": {
     "t1": "Dragon",
@@ -4107,7 +4444,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 87,
       "sp": 23
     },
-    "w": 23.8
+      "w": 23.8,
+      "canEvolve": true,
   },
   "Linoone": {
     "t1": "Normal",
@@ -4119,7 +4457,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 61,
       "sp": 100
     },
-    "w": 32.5
+      "w": 32.5,
+      "ab": "Pickup",
   },
   "Lombre": {
     "t1": "Water",
@@ -4132,7 +4471,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 70,
       "sp": 50
     },
-    "w": 32.5
+      "w": 32.5,
+      "canEvolve": true,
   },
   "Lotad": {
     "t1": "Water",
@@ -4145,7 +4485,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 50,
       "sp": 30
     },
-    "w": 2.6
+      "w": 2.6,
+      "canEvolve": true,
   },
   "Loudred": {
     "t1": "Normal",
@@ -4158,7 +4499,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 48
     },
     "w": 40.5,
-    "ab": "Soundproof"
+      "ab": "Soundproof",
+      "canEvolve": true,
   },
   "Ludicolo": {
     "t1": "Water",
@@ -4171,7 +4513,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 100,
       "sp": 70
     },
-    "w": 55.0
+      "w": 55.0,
+      "ab": "Swift Swim",
   },
   "Lunatone": {
     "t1": "Rock",
@@ -4210,7 +4553,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 25
     },
-    "w": 86.4
+      "w": 86.4,
+      "canEvolve": true,
   },
   "Manectric": {
     "t1": "Electric",
@@ -4222,7 +4566,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 105
     },
-    "w": 40.2
+      "w": 40.2,
+      "ab": "Lightning Rod",
   },
   "Marshtomp": {
     "t1": "Water",
@@ -4236,7 +4581,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 50
     },
     "w": 28.0,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Masquerain": {
     "t1": "Bug",
@@ -4262,7 +4608,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 55,
       "sp": 50
     },
-    "w": 11.5
+      "w": 11.5,
+      "ab": "Intimidate",
   },
   "Medicham": {
     "t1": "Fighting",
@@ -4290,7 +4637,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 60
     },
     "w": 11.2,
-    "ab": "Pure Power"
+      "ab": "Pure Power",
+      "canEvolve": true,
   },
   "Metagross": {
     "t1": "Steel",
@@ -4318,7 +4666,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 50
     },
     "w": 202.5,
-    "ab": "Clear Body"
+      "ab": "Clear Body",
+      "canEvolve": true,
   },
   "Mightyena": {
     "t1": "Dark",
@@ -4343,7 +4692,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 125,
       "sp": 81
     },
-    "w": 162.0
+      "w": 162.0,
+      "ab": "Marvel Scale",
   },
   "Minun": {
     "t1": "Electric",
@@ -4355,7 +4705,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 85,
       "sp": 95
     },
-    "w": 4.2
+      "w": 4.2,
+      "ab": "Minus",
   },
   "Mudkip": {
     "t1": "Water",
@@ -4368,7 +4719,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 40
     },
     "w": 7.6,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Nincada": {
     "t1": "Bug",
@@ -4381,7 +4733,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 40
     },
-    "w": 5.5
+      "w": 5.5,
+      "canEvolve": true,
   },
   "Ninjask": {
     "t1": "Bug",
@@ -4394,7 +4747,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 50,
       "sp": 160
     },
-    "w": 12.0
+      "w": 12.0,
+      "ab": "Speed Boost",
   },
   "Nosepass": {
     "t1": "Rock",
@@ -4406,7 +4760,9 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 90,
       "sp": 30
     },
-    "w": 97.0
+      "w": 97.0,
+      "ab": "Magnet Pull",
+      "canEvolve": true,
   },
   "Numel": {
     "t1": "Fire",
@@ -4419,7 +4775,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 45,
       "sp": 35
     },
-    "w": 24.0
+      "w": 24.0,
+      "canEvolve": true,
   },
   "Nuzleaf": {
     "t1": "Grass",
@@ -4432,7 +4789,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 40,
       "sp": 60
     },
-    "w": 28.0
+      "w": 28.0,
+      "canEvolve": true,
   },
   "Pelipper": {
     "t1": "Water",
@@ -4445,7 +4803,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 70,
       "sp": 65
     },
-    "w": 28.0
+      "w": 28.0,
+      "ab": "Keen Eye",
   },
   "Plusle": {
     "t1": "Electric",
@@ -4457,7 +4816,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 75,
       "sp": 95
     },
-    "w": 4.2
+      "w": 4.2,
+      "ab": "Plus",
   },
   "Poochyena": {
     "t1": "Dark",
@@ -4469,7 +4829,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 35
     },
-    "w": 13.6
+      "w": 13.6,
+      "canEvolve": true,
   },
   "Ralts": {
     "t1": "Psychic",
@@ -4481,7 +4842,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 35,
       "sp": 40
     },
-    "w": 6.6
+      "w": 6.6,
+      "canEvolve": true,
   },
   "Rayquaza": {
     "t1": "Dragon",
@@ -4547,7 +4909,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 65,
       "sp": 55
     },
-    "w": 23.4
+      "w": 23.4,
+      "ab": "Swift Swim",
   },
   "Roselia": {
     "t1": "Grass",
@@ -4560,7 +4923,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 80,
       "sp": 65
     },
-    "w": 2.0
+      "w": 2.0,
+      "canEvolve": true,
   },
   "Sableye": {
     "t1": "Dark",
@@ -4573,7 +4937,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 65,
       "sp": 50
     },
-    "w": 11.0
+      "w": 11.0,
+      "ab": "Keen Eye",
   },
   "Salamence": {
     "t1": "Dragon",
@@ -4614,7 +4979,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 45
     },
     "w": 87.6,
-    "ab": "Thick Fat"
+      "ab": "Thick Fat",
+      "canEvolve": true,
   },
   "Seedot": {
     "t1": "Grass",
@@ -4626,7 +4992,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 30
     },
-    "w": 4.0
+      "w": 4.0,
+      "canEvolve": true,
   },
   "Seviper": {
     "t1": "Poison",
@@ -4638,7 +5005,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 65
     },
-    "w": 52.5
+      "w": 52.5,
+      "ab": "Shed Skin",
   },
   "Sharpedo": {
     "t1": "Water",
@@ -4651,7 +5019,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 40,
       "sp": 95
     },
-    "w": 88.8
+      "w": 88.8,
+      "ab": "Rough Skin",
   },
   "Shedinja": {
     "t1": "Bug",
@@ -4677,7 +5046,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 50,
       "sp": 50
     },
-    "w": 110.5
+      "w": 110.5,
+      "canEvolve": true,
   },
   "Shiftry": {
     "t1": "Grass",
@@ -4690,7 +5060,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 80
     },
-    "w": 59.6
+      "w": 59.6,
+      "ab": "Chlorophyll",
   },
   "Shroomish": {
     "t1": "Grass",
@@ -4702,7 +5073,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 35
     },
-    "w": 4.5
+      "w": 4.5,
+      "canEvolve": true,
   },
   "Shuppet": {
     "t1": "Ghost",
@@ -4714,7 +5086,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 33,
       "sp": 45
     },
-    "w": 2.3
+      "w": 2.3,
+      "canEvolve": true,
   },
   "Silcoon": {
     "t1": "Bug",
@@ -4727,7 +5100,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 15
     },
     "w": 10.0,
-    "ab": "Shed Skin"
+      "ab": "Shed Skin",
+      "canEvolve": true,
   },
   "Skitty": {
     "t1": "Normal",
@@ -4739,7 +5113,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 35,
       "sp": 50
     },
-    "w": 11.0
+      "w": 11.0,
+      "canEvolve": true,
   },
   "Slaking": {
     "t1": "Normal",
@@ -4765,7 +5140,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 30
     },
     "w": 24.0,
-    "ab": "Truant"
+      "ab": "Truant",
+      "canEvolve": true,
   },
   "Snorunt": {
     "t1": "Ice",
@@ -4777,7 +5153,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 50,
       "sp": 50
     },
-    "w": 16.8
+      "w": 16.8,
+      "canEvolve": true,
   },
   "Solrock": {
     "t1": "Rock",
@@ -4805,7 +5182,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 25
     },
     "w": 39.5,
-    "ab": "Thick Fat"
+      "ab": "Thick Fat",
+      "canEvolve": true,
   },
   "Spinda": {
     "t1": "Normal",
@@ -4817,7 +5195,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 60
     },
-    "w": 5.0
+      "w": 5.0,
+      "ab": "Own Tempo",
   },
   "Spoink": {
     "t1": "Psychic",
@@ -4829,7 +5208,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 80,
       "sp": 60
     },
-    "w": 30.6
+      "w": 30.6,
+      "canEvolve": true,
   },
   "Surskit": {
     "t1": "Bug",
@@ -4843,7 +5223,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 65
     },
     "w": 1.7,
-    "ab": "Swift Swim"
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Swablu": {
     "t1": "Normal",
@@ -4856,7 +5237,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 75,
       "sp": 50
     },
-    "w": 1.2
+      "w": 1.2,
+      "canEvolve": true,
   },
   "Swalot": {
     "t1": "Poison",
@@ -4868,7 +5250,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 83,
       "sp": 55
     },
-    "w": 80.0
+      "w": 80.0,
+      "ab": "Sticky Hold",
   },
   "Swampert": {
     "t1": "Water",
@@ -4910,7 +5293,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 85
     },
     "w": 2.3,
-    "ab": "Guts"
+      "ab": "Guts",
+      "canEvolve": true,
   },
   "Torchic": {
     "t1": "Fire",
@@ -4923,7 +5307,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 45
     },
     "w": 2.5,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Torkoal": {
     "t1": "Fire",
@@ -4948,7 +5333,9 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 45,
       "sp": 10
     },
-    "w": 15.0
+      "w": 15.0,
+      "ab": "Arena Trap",
+      "canEvolve": true,
   },
   "Treecko": {
     "t1": "Grass",
@@ -4961,7 +5348,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 70
     },
     "w": 5.0,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Tropius": {
     "t1": "Grass",
@@ -4989,7 +5377,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 70
     },
     "w": 15.3,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Vigoroth": {
     "t1": "Normal",
@@ -5002,7 +5391,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 90
     },
     "w": 46.5,
-    "ab": "Vital Spirit"
+      "ab": "Vital Spirit",
+      "canEvolve": true,
   },
   "Volbeat": {
     "t1": "Bug",
@@ -5014,7 +5404,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 75,
       "sp": 85
     },
-    "w": 17.7
+      "w": 17.7,
+      "ab": "Swarm",
   },
   "Wailmer": {
     "t1": "Water",
@@ -5026,7 +5417,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 35,
       "sp": 60
     },
-    "w": 130.0
+      "w": 130.0,
+      "canEvolve": true,
   },
   "Wailord": {
     "t1": "Water",
@@ -5038,7 +5430,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 45,
       "sp": 60
     },
-    "w": 398.0
+      "w": 398.0,
+      "ab": "Water Veil",
   },
   "Walrein": {
     "t1": "Ice",
@@ -5065,7 +5458,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 71,
       "sp": 60
     },
-    "w": 23.6
+      "w": 23.6,
+      "ab": "Oblivious",
   },
   "Whismur": {
     "t1": "Normal",
@@ -5078,7 +5472,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sp": 28
     },
     "w": 16.3,
-    "ab": "Soundproof"
+      "ab": "Soundproof",
+      "canEvolve": true,
   },
   "Wingull": {
     "t1": "Water",
@@ -5091,7 +5486,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 85
     },
-    "w": 9.5
+      "w": 9.5,
+      "canEvolve": true,
   },
   "Wurmple": {
     "t1": "Bug",
@@ -5103,7 +5499,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 30,
       "sp": 20
     },
-    "w": 3.6
+      "w": 3.6,
+      "canEvolve": true,
   },
   "Wynaut": {
     "t1": "Psychic",
@@ -5115,7 +5512,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 48,
       "sp": 23
     },
-    "w": 14.0
+      "w": 14.0,
+      "canEvolve": true,
   },
   "Zangoose": {
     "t1": "Normal",
@@ -5127,7 +5525,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 60,
       "sp": 90
     },
-    "w": 40.3
+      "w": 40.3,
+      "ab": "Immunity",
   },
   "Zigzagoon": {
     "t1": "Normal",
@@ -5139,7 +5538,8 @@ var POKEDEX_ADV = $.extend(true, {}, POKEDEX_GSC, {
       "sd": 41,
       "sp": 60
     },
-    "w": 17.5
+      "w": 17.5,
+      "canEvolve": true,
   }
 });
 
@@ -5168,7 +5568,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 66,
       "sp": 115
     },
-    "w": 20.3
+      "w": 20.3,
+      "ab": "Technician",
   },
   "Arceus": {
     "t1": "Normal",
@@ -5207,7 +5608,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 138,
       "sp": 30
     },
-    "w": 149.5
+      "w": 149.5,
+      "ab": "Sturdy",
   },
   "Bibarel": {
     "t1": "Normal",
@@ -5220,7 +5622,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 60,
       "sp": 71
     },
-    "w": 31.5
+      "w": 31.5,
+      "ab": "Unaware",
   },
   "Bidoof": {
     "t1": "Normal",
@@ -5232,7 +5635,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 40,
       "sp": 31
     },
-    "w": 20.0
+      "w": 20.0,
+      "canEvolve": true,
   },
   "Bonsly": {
     "t1": "Rock",
@@ -5244,7 +5648,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 45,
       "sp": 10
     },
-    "w": 15.0
+      "w": 15.0,
+      "canEvolve": true,
   },
   "Bronzong": {
     "t1": "Steel",
@@ -5257,7 +5662,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 116,
       "sp": 33
     },
-    "w": 187.0
+      "w": 187.0,
+      "ab": "Levitate",
   },
   "Bronzor": {
     "t1": "Steel",
@@ -5270,7 +5676,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 86,
       "sp": 23
     },
-    "w": 60.5
+      "w": 60.5,
+      "canEvolve": true,
   },
   "Budew": {
     "t1": "Grass",
@@ -5283,7 +5690,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 70,
       "sp": 55
     },
-    "w": 1.2
+      "w": 1.2,
+      "canEvolve": true,
   },
   "Buizel": {
     "t1": "Water",
@@ -5296,7 +5704,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 85
     },
     "w": 29.5,
-    "ab": "Swift Swim"
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Buneary": {
     "t1": "Normal",
@@ -5308,7 +5717,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 56,
       "sp": 85
     },
-    "w": 5.5
+      "w": 5.5,
+      "canEvolve": true,
   },
   "Burmy": {
     "t1": "Bug",
@@ -5320,7 +5730,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 45,
       "sp": 36
     },
-    "w": 3.4
+      "w": 3.4,
+      "canEvolve": true,
   },
   "Carnivine": {
     "t1": "Grass",
@@ -5372,7 +5783,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 35
     },
     "w": 3.3,
-    "ab": "Chlorophyll"
+      "ab": "Chlorophyll",
+      "canEvolve": true,
   },
   "Chimchar": {
     "t1": "Fire",
@@ -5385,7 +5797,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 61
     },
     "w": 6.2,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Chingling": {
     "t1": "Psychic",
@@ -5398,7 +5811,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 45
     },
     "w": 0.6,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Combee": {
     "t1": "Bug",
@@ -5411,7 +5825,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 42,
       "sp": 70
     },
-    "w": 5.5
+      "w": 5.5,
+      "canEvolve": true,
   },
   "Cranidos": {
     "t1": "Rock",
@@ -5423,7 +5838,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 30,
       "sp": 58
     },
-    "w": 31.5
+      "w": 31.5,
+      "canEvolve": true,
   },
   "Cresselia": {
     "t1": "Psychic",
@@ -5449,7 +5865,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 40,
       "sp": 50
     },
-    "w": 23.0
+      "w": 23.0,
+      "canEvolve": true,
   },
   "Darkrai": {
     "t1": "Dark",
@@ -5475,7 +5892,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 100,
       "sp": 90
     },
-    "w": 683.0
+      "w": 683.0,
+      "ab": "Pressure",
   },
   "Drapion": {
     "t1": "Poison",
@@ -5488,7 +5906,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 75,
       "sp": 95
     },
-    "w": 61.5
+      "w": 61.5,
+      "ab": "Sniper",
   },
   "Drifblim": {
     "t1": "Ghost",
@@ -5501,7 +5920,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 54,
       "sp": 80
     },
-    "w": 15.0
+      "w": 15.0,
+      "ab": "Unburden",
   },
   "Drifloon": {
     "t1": "Ghost",
@@ -5514,7 +5934,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 44,
       "sp": 70
     },
-    "w": 1.2
+      "w": 1.2,
+      "canEvolve": true,
   },
   "Dusknoir": {
     "t1": "Ghost",
@@ -5526,7 +5947,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 135,
       "sp": 45
     },
-    "w": 106.6
+      "w": 106.6,
+      "ab": "Pressure",
   },
   "Electivire": {
     "t1": "Electric",
@@ -5565,7 +5987,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 61,
       "sp": 66
     },
-    "w": 7.0
+      "w": 7.0,
+      "canEvolve": true,
   },
   "Floatzel": {
     "t1": "Water",
@@ -5606,7 +6029,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 82
     },
     "w": 56.0,
-    "ab": "Sand Veil"
+      "ab": "Sand Veil",
+      "canEvolve": true,
   },
   "Gallade": {
     "t1": "Psychic",
@@ -5619,7 +6043,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 115,
       "sp": 80
     },
-    "w": 52.0
+      "w": 52.0,
+      "ab": "Steadfast",
   },
   "Garchomp": {
     "t1": "Dragon",
@@ -5646,7 +6071,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 82,
       "sp": 39
     },
-    "w": 29.9
+      "w": 29.9,
+      "ab": "Storm Drain",
   },
   "Gible": {
     "t1": "Dragon",
@@ -5660,7 +6086,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 42
     },
     "w": 20.5,
-    "ab": "Sand Veil"
+      "ab": "Sand Veil",
+      "canEvolve": true,
   },
   "Giratina": {
     "t1": "Ghost",
@@ -5673,7 +6100,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 120,
       "sp": 90
     },
-    "w": 750.0
+      "w": 750.0,
+      "ab": "Pressure",
   },
   "Giratina-Origin": {
     "t1": "Ghost",
@@ -5712,7 +6140,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 37,
       "sp": 85
     },
-    "w": 3.9
+      "w": 3.9,
+      "canEvolve": true,
   },
   "Gliscor": {
     "t1": "Ground",
@@ -5725,7 +6154,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 75,
       "sp": 95
     },
-    "w": 42.5
+      "w": 42.5,
+      "ab": "Hyper Cutter",
   },
   "Grotle": {
     "t1": "Grass",
@@ -5738,7 +6168,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 36
     },
     "w": 97.0,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Happiny": {
     "t1": "Normal",
@@ -5750,7 +6181,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 65,
       "sp": 30
     },
-    "w": 24.4
+      "w": 24.4,
+      "canEvolve": true,
   },
   "Heatran": {
     "t1": "Fire",
@@ -5777,7 +6209,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 32
     },
     "w": 49.5,
-    "ab": "Sand Stream"
+      "ab": "Sand Stream",
+      "canEvolve": true,
   },
   "Hippowdon": {
     "t1": "Ground",
@@ -5803,7 +6236,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 52,
       "sp": 71
     },
-    "w": 27.3
+      "w": 27.3,
+      "ab": "Super Luck",
   },
   "Infernape": {
     "t1": "Fire",
@@ -5829,7 +6263,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 41,
       "sp": 25
     },
-    "w": 2.2
+      "w": 2.2,
+      "canEvolve": true,
   },
   "Kricketune": {
     "t1": "Bug",
@@ -5866,7 +6301,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 95,
       "sp": 50
     },
-    "w": 140.0
+      "w": 140.0,
+      "ab": "Own Tempo",
   },
   "Lopunny": {
     "t1": "Normal",
@@ -5878,7 +6314,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 96,
       "sp": 105
     },
-    "w": 33.3
+      "w": 33.3,
+      "ab": "Klutz",
   },
   "Lucario": {
     "t1": "Fighting",
@@ -5891,7 +6328,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 70,
       "sp": 90
     },
-    "w": 54.0
+      "w": 54.0,
+      "ab": "Inner Focus",
   },
   "Lumineon": {
     "t1": "Water",
@@ -5903,7 +6341,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 86,
       "sp": 91
     },
-    "w": 24.0
+      "w": 24.0,
+      "ab": "Swift Swim",
   },
   "Luxio": {
     "t1": "Electric",
@@ -5915,7 +6354,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 49,
       "sp": 60
     },
-    "w": 30.5
+      "w": 30.5,
+      "canEvolve": true,
   },
   "Luxray": {
     "t1": "Electric",
@@ -5927,7 +6367,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 79,
       "sp": 70
     },
-    "w": 42.0
+      "w": 42.0,
+      "ab": "Intimidate",
   },
   "Magmortar": {
     "t1": "Fire",
@@ -5939,7 +6380,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 95,
       "sp": 83
     },
-    "w": 68.0
+      "w": 68.0,
+      "ab": "Flame Body",
   },
   "Magnezone": {
     "t1": "Electric",
@@ -5952,7 +6394,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 90,
       "sp": 60
     },
-    "w": 180.0
+      "w": 180.0,
+      "ab": "Magnet Pull",
   },
   "Mamoswine": {
     "t1": "Ice",
@@ -5965,7 +6408,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 60,
       "sp": 80
     },
-    "w": 291.0
+      "w": 291.0,
+      "ab": "Oblivious",
   },
   "Manaphy": {
     "t1": "Water",
@@ -5991,7 +6435,9 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 120,
       "sp": 50
     },
-    "w": 65.0
+      "w": 65.0,
+      "ab": "Water Absorb",
+      "canEvolve": true,
   },
   "Mesprit": {
     "t1": "Psychic",
@@ -6016,7 +6462,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 90,
       "sp": 60
     },
-    "w": 13.0
+      "w": 13.0,
+      "canEvolve": true,
   },
   "Mismagius": {
     "t1": "Ghost",
@@ -6043,7 +6490,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 81
     },
     "w": 22.0,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Mothim": {
     "t1": "Bug",
@@ -6069,7 +6517,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 85,
       "sp": 5
     },
-    "w": 105.0
+      "w": 105.0,
+      "canEvolve": true,
   },
   "Pachirisu": {
     "t1": "Electric",
@@ -6094,7 +6543,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 120,
       "sp": 100
     },
-    "w": 336.0
+      "w": 336.0,
+      "ab": "Pressure",
   },
   "Phione": {
     "t1": "Water",
@@ -6120,7 +6570,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 40
     },
     "w": 5.2,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Porygon-Z": {
     "t1": "Normal",
@@ -6132,7 +6583,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 75,
       "sp": 90
     },
-    "w": 34.0
+      "w": 34.0,
+      "ab": "Adaptability",
   },
   "Prinplup": {
     "t1": "Water",
@@ -6145,7 +6597,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 50
     },
     "w": 23.0,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Probopass": {
     "t1": "Rock",
@@ -6158,7 +6611,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 150,
       "sp": 40
     },
-    "w": 340.0
+      "w": 340.0,
+      "ab": "Magnet Pull",
   },
   "Purugly": {
     "t1": "Normal",
@@ -6170,7 +6624,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 59,
       "sp": 112
     },
-    "w": 43.8
+      "w": 43.8,
+      "ab": "Thick Fat",
   },
   "Rampardos": {
     "t1": "Rock",
@@ -6182,7 +6637,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 50,
       "sp": 58
     },
-    "w": 102.5
+      "w": 102.5,
+      "ab": "Mold Breaker",
   },
   "Regigigas": {
     "t1": "Normal",
@@ -6208,7 +6664,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 55,
       "sp": 40
     },
-    "w": 282.8
+      "w": 282.8,
+      "ab": "Solid Rock",
   },
   "Riolu": {
     "t1": "Fighting",
@@ -6220,7 +6677,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 40,
       "sp": 60
     },
-    "w": 20.2
+      "w": 20.2,
+      "canEvolve": true,
   },
   "Roserade": {
     "t1": "Grass",
@@ -6233,7 +6691,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 105,
       "sp": 90
     },
-    "w": 14.5
+      "w": 14.5,
+      "ab": "Natural Cure",
   },
   "Rotom": {
     "t1": "Electric",
@@ -6356,7 +6815,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 62,
       "sp": 34
     },
-    "w": 6.3
+      "w": 6.3,
+      "canEvolve": true,
   },
   "Shieldon": {
     "t1": "Rock",
@@ -6369,7 +6829,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 88,
       "sp": 30
     },
-    "w": 57.0
+      "w": 57.0,
+      "canEvolve": true,
   },
   "Shinx": {
     "t1": "Electric",
@@ -6381,7 +6842,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 34,
       "sp": 45
     },
-    "w": 9.5
+      "w": 9.5,
+      "canEvolve": true,
   },
   "Skorupi": {
     "t1": "Poison",
@@ -6394,7 +6856,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 55,
       "sp": 65
     },
-    "w": 12.0
+      "w": 12.0,
+      "canEvolve": true,
   },
   "Skuntank": {
     "t1": "Poison",
@@ -6407,7 +6870,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 61,
       "sp": 84
     },
-    "w": 38.0
+      "w": 38.0,
+      "ab": "Aftermath",
   },
   "Snover": {
     "t1": "Grass",
@@ -6421,7 +6885,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 40
     },
     "w": 50.5,
-    "ab": "Snow Warning"
+      "ab": "Snow Warning",
+      "canEvolve": true,
   },
   "Spiritomb": {
     "t1": "Ghost",
@@ -6434,7 +6899,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 108,
       "sp": 35
     },
-    "w": 108.0
+      "w": 108.0,
+      "ab": "Pressure",
   },
   "Staraptor": {
     "t1": "Normal",
@@ -6462,7 +6928,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 80
     },
     "w": 15.5,
-    "ab": "Intimidate"
+      "ab": "Intimidate",
+      "canEvolve": true,
   },
   "Starly": {
     "t1": "Normal",
@@ -6475,7 +6942,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 30,
       "sp": 60
     },
-    "w": 2.0
+      "w": 2.0,
+      "canEvolve": true,
   },
   "Stunky": {
     "t1": "Poison",
@@ -6488,7 +6956,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 41,
       "sp": 74
     },
-    "w": 19.2
+      "w": 19.2,
+      "canEvolve": true,
   },
   "Tangrowth": {
     "t1": "Grass",
@@ -6500,7 +6969,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 50,
       "sp": 50
     },
-    "w": 128.6
+      "w": 128.6,
+      "ab": "Chlorophyll",
   },
   "Togekiss": {
     "t1": "Normal",
@@ -6513,7 +6983,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 115,
       "sp": 80
     },
-    "w": 38.0
+      "w": 38.0,
+      "ab": "Serene Grace",
   },
   "Torterra": {
     "t1": "Grass",
@@ -6540,7 +7011,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 65,
       "sp": 85
     },
-    "w": 44.4
+      "w": 44.4,
+      "ab": "Dry Skin",
   },
   "Turtwig": {
     "t1": "Grass",
@@ -6553,7 +7025,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sp": 31
     },
     "w": 10.2,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Uxie": {
     "t1": "Psychic",
@@ -6592,7 +7065,8 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 85,
       "sp": 125
     },
-    "w": 34.0
+      "w": 34.0,
+      "ab": "Pressure",
   },
   "Wormadam": {
     "t1": "Bug",
@@ -6644,41 +7118,25 @@ var POKEDEX_DPP = $.extend(true, {}, POKEDEX_ADV, {
       "sd": 56,
       "sp": 95
     },
-    "w": 51.5
-  }
+      "w": 51.5,
+      "ab": "Speed Boost",
+    },
+  //ABILITY DIFFERENCE
+    "Clefable": { "ab": "Magic Guard" },
+    "Parasect": { "ab": "Dry Skin" },
+    "Machamp": { "ab": "No Guard" },
+    "Cloyster": { "ab": "Skill Link" },
+    "Hitmonlee": { "ab": "Reckless" },
+    "Hitmonchan": { "ab": "Iron Fist" },
+    "Kangaskhan": { "ab": "Scrappy" },
+    "Scizor": { "ab": "Technician" },
+    "Sunflora": { "ab": "Solar Power" },
+    "Miltank": { "ab": "Scrappy" },
+    "Linoone": { "ab": "Gluttony" },
+    "Breloom": { "ab": "Poison Heal" },
+    "Delcatty": { "ab": "Normalize" },
+    "Camerupt": { "ab": "Solid Rock" },
 });
-
-delete POKEDEX_DPP['Machop'].ab;
-delete POKEDEX_DPP['Machoke'].ab;
-delete POKEDEX_DPP['Machamp'].ab;
-delete POKEDEX_DPP['Seel'].ab;
-delete POKEDEX_DPP['Dewgong'].ab;
-delete POKEDEX_DPP['Shellder'].ab;
-delete POKEDEX_DPP['Cloyster'].ab;
-delete POKEDEX_DPP['Tangela'].ab;
-delete POKEDEX_DPP['Horsea'].ab;
-delete POKEDEX_DPP['Mr. Mime'].ab;
-delete POKEDEX_DPP['Scyther'].ab;
-delete POKEDEX_DPP['Pinsir'].ab;
-delete POKEDEX_DPP['Tauros'].ab;
-delete POKEDEX_DPP['Hoppip'].ab;
-delete POKEDEX_DPP['Skiploom'].ab;
-delete POKEDEX_DPP['Jumpluff'].ab;
-delete POKEDEX_DPP['Sunkern'].ab;
-delete POKEDEX_DPP['Sunflora'].ab;
-delete POKEDEX_DPP['Granbull'].ab;
-delete POKEDEX_DPP['Scizor'].ab;
-delete POKEDEX_DPP['Ursaring'].ab;
-delete POKEDEX_DPP['Kingdra'].ab;
-delete POKEDEX_DPP['Stantler'].ab;
-delete POKEDEX_DPP['Tyrogue'].ab;
-delete POKEDEX_DPP['Hitmontop'].ab;
-delete POKEDEX_DPP['Miltank'].ab;
-delete POKEDEX_DPP['Mightyena'].ab;
-delete POKEDEX_DPP['Tropius'].ab;
-delete POKEDEX_DPP['Spheal'].ab;
-delete POKEDEX_DPP['Sealeo'].ab;
-delete POKEDEX_DPP['Walrein'].ab;
 
 var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
   "Rotom-Mow": { "t2": "Grass" },
@@ -6696,7 +7154,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 145
     },
-    "w": 25.3
+      "w": 25.3,
+      "ab": "Unburden",
   },
   "Alomomola": {
     "t1": "Water",
@@ -6708,7 +7167,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 65
     },
-    "w": 31.6
+      "w": 31.6,
+      "ab": "Regenerator",
   },
   "Amoonguss": {
     "t1": "Grass",
@@ -6721,7 +7181,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 30
     },
-    "w": 10.5
+      "w": 10.5,
+      "ab": "Regenerator",
   },
   "Archen": {
     "t1": "Rock",
@@ -6735,7 +7196,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 70
     },
     "w": 9.5,
-    "ab": "Defeatist"
+      "ab": "Defeatist",
+      "canEvolve": true,
   },
   "Archeops": {
     "t1": "Rock",
@@ -6761,7 +7223,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 86,
       "sp": 50
     },
-    "w": 31.0
+      "w": 31.0,
+      "ab": "Regenerator",
   },
   "Axew": {
     "t1": "Dragon",
@@ -6773,7 +7236,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 57
     },
-    "w": 18.0
+      "w": 18.0,
+      "canEvolve": true,
   },
   "Basculin": {
     "t1": "Water",
@@ -6797,7 +7261,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 50
     },
-    "w": 260.0
+      "w": 260.0,
+      "ab": "Swift Swim",
   },
   "Beheeyem": {
     "t1": "Psychic",
@@ -6809,7 +7274,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 95,
       "sp": 40
     },
-    "w": 34.5
+      "w": 34.5,
+      "ab": "Analytic",
   },
   "Bisharp": {
     "t1": "Dark",
@@ -6822,7 +7288,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 70
     },
-    "w": 70.0
+      "w": 70.0,
+      "ab": "Defiant",
   },
   "Blitzle": {
     "t1": "Electric",
@@ -6834,7 +7301,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 32,
       "sp": 76
     },
-    "w": 29.8
+        "w": 29.8,
+        "canEvolve": true,
   },
   "Boldore": {
     "t1": "Rock",
@@ -6846,7 +7314,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 20
     },
-    "w": 102.0
+      "w": 102.0,
+      "canEvolve": true,
   },
   "Bouffalant": {
     "t1": "Normal",
@@ -6858,7 +7327,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 95,
       "sp": 55
     },
-    "w": 94.6
+      "w": 94.6,
+      "ab": "Reckless",
   },
   "Braviary": {
     "t1": "Normal",
@@ -6871,7 +7341,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 80
     },
-    "w": 41.0
+      "w": 41.0,
+      "ab": "Defiant",
   },
   "Carracosta": {
     "t1": "Water",
@@ -6884,7 +7355,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 32
     },
-    "w": 81.0
+      "w": 81.0,
+      "ab": "Solid Rock",
   },
   "Chandelure": {
     "t1": "Ghost",
@@ -6897,7 +7369,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 90,
       "sp": 80
     },
-    "w": 34.3
+      "w": 34.3,
+      "ab": "Flash Fire",
   },
   "Cinccino": {
     "t1": "Normal",
@@ -6909,7 +7382,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 115
     },
-    "w": 7.5
+      "w": 7.5,
+      "ab": "Skill Link",
   },
   "Cobalion": {
     "t1": "Steel",
@@ -6960,7 +7434,9 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 66
     },
-    "w": 0.6
+      "w": 0.6,
+      "ab": "Prankster",
+      "canEvolve": true,
   },
   "Crustle": {
     "t1": "Bug",
@@ -6973,7 +7449,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 45
     },
-    "w": 200.0
+      "w": 200.0,
+      "ab": "Sturdy",
   },
   "Cryogonal": {
     "t1": "Ice",
@@ -6998,7 +7475,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 40
     },
-    "w": 8.5
+      "w": 8.5,
+      "canEvolve": true,
   },
   "Darmanitan": {
     "t1": "Fire",
@@ -7013,10 +7491,11 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
     "w": 92.9,
     "formes": [
       "Darmanitan",
-      "Darmanitan-Z"
-    ]
+      "Darmanitan-Zen"
+      ],
+      "ab": "Sheer Force",
   },
-  "Darmanitan-Z": {
+  "Darmanitan-Zen": {
     "t1": "Fire",
     "t2": "Psychic",
     "bs": {
@@ -7041,7 +7520,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 50
     },
-    "w": 37.5
+        "w": 37.5,
+        "canEvolve": true,
   },
   "Deerling": {
     "t1": "Normal",
@@ -7054,7 +7534,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 75
     },
-    "w": 19.5
+      "w": 19.5,
+      "canEvolve": true,
   },
   "Deino": {
     "t1": "Dark",
@@ -7068,7 +7549,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 38
     },
     "w": 17.3,
-    "ab": "Hustle"
+      "ab": "Hustle",
+      "canEvolve": true,
   },
   "Dewott": {
     "t1": "Water",
@@ -7081,7 +7563,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 60
     },
     "w": 24.5,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Drilbur": {
     "t1": "Ground",
@@ -7093,7 +7576,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 68
     },
-    "w": 8.5
+      "w": 8.5,
+      "canEvolve": true,
   },
   "Druddigon": {
     "t1": "Dragon",
@@ -7105,7 +7589,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 90,
       "sp": 48
     },
-    "w": 139.0
+      "w": 139.0,
+      "ab": "Mold Breaker",
   },
   "Ducklett": {
     "t1": "Water",
@@ -7118,7 +7603,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 55
     },
-    "w": 5.5
+      "w": 5.5,
+      "canEvolve": true,
   },
   "Duosion": {
     "t1": "Psychic",
@@ -7130,7 +7616,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 30
     },
-    "w": 8.0
+      "w": 8.0,
+      "canEvolve": true,
   },
   "Durant": {
     "t1": "Bug",
@@ -7143,7 +7630,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 48,
       "sp": 109
     },
-    "w": 33.0
+      "w": 33.0,
+      "ab": "Hustle",
   },
   "Dwebble": {
     "t1": "Bug",
@@ -7156,7 +7644,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 35,
       "sp": 55
     },
-    "w": 14.5
+      "w": 14.5,
+      "canEvolve": true,
   },
   "Eelektrik": {
     "t1": "Electric",
@@ -7169,7 +7658,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 40
     },
     "w": 22.0,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Eelektross": {
     "t1": "Electric",
@@ -7194,7 +7684,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 30
     },
-    "w": 9.0
+      "w": 9.0,
+      "canEvolve": true,
   },
   "Emboar": {
     "t1": "Fire",
@@ -7234,7 +7725,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 105,
       "sp": 20
     },
-    "w": 33.0
+      "w": 33.0,
+      "ab": "Swarm",
   },
   "Excadrill": {
     "t1": "Ground",
@@ -7247,7 +7739,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 88
     },
-    "w": 40.4
+      "w": 40.4,
+      "ab": "Sand Rush",
   },
   "Ferroseed": {
     "t1": "Grass",
@@ -7260,7 +7753,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 86,
       "sp": 10
     },
-    "w": 18.8
+      "w": 18.8,
+      "canEvolve": true,
   },
   "Ferrothorn": {
     "t1": "Grass",
@@ -7273,7 +7767,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 116,
       "sp": 20
     },
-    "w": 110.0
+      "w": 110.0,
+      "ab": "Iron Barbs",
   },
   "Foongus": {
     "t1": "Grass",
@@ -7286,7 +7781,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 15
     },
-    "w": 1.0
+      "w": 1.0,
+      "canEvolve": true,
   },
   "Fraxure": {
     "t1": "Dragon",
@@ -7298,7 +7794,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 67
     },
-    "w": 36.0
+      "w": 36.0,
+      "canEvolve": true,
   },
   "Frillish": {
     "t1": "Water",
@@ -7311,7 +7808,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 40
     },
-    "w": 33.0
+      "w": 33.0,
+      "canEvolve": true,
   },
   "Galvantula": {
     "t1": "Bug",
@@ -7324,7 +7822,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 108
     },
-    "w": 14.3
+      "w": 14.3,
+      "ab": "Compound Eyes",
   },
   "Garbodor": {
     "t1": "Poison",
@@ -7363,7 +7862,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 25
     },
-    "w": 260.0
+      "w": 260.0,
+      "ab": "Sturdy",
   },
   "Golett": {
     "t1": "Ground",
@@ -7376,7 +7876,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 35
     },
-    "w": 92.0
+      "w": 92.0,
+      "canEvolve": true,
   },
   "Golurk": {
     "t1": "Ground",
@@ -7389,7 +7890,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 55
     },
-    "w": 330.0
+      "w": 330.0,
+      "ab": "Iron Fist",
   },
   "Gothita": {
     "t1": "Psychic",
@@ -7401,7 +7903,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 45
     },
-    "w": 5.8
+      "w": 5.8,
+      "canEvolve": true,
   },
   "Gothitelle": {
     "t1": "Psychic",
@@ -7413,7 +7916,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 110,
       "sp": 65
     },
-    "w": 44.0
+      "w": 44.0,
+      "ab": "Shadow Tag",
   },
   "Gothorita": {
     "t1": "Psychic",
@@ -7425,7 +7929,9 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 55
     },
-    "w": 18.0
+      "w": 18.0,
+      "ab": "Shadow Tag",
+      "canEvolve": true,
   },
   "Gurdurr": {
     "t1": "Fighting",
@@ -7437,7 +7943,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 40
     },
-    "w": 40.0
+      "w": 40.0,
+      "canEvolve": true,
   },
   "Haxorus": {
     "t1": "Dragon",
@@ -7449,7 +7956,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 97
     },
-    "w": 105.5
+      "w": 105.5,
+      "ab": "Mold Breaker",
   },
   "Heatmor": {
     "t1": "Fire",
@@ -7473,7 +7981,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 60
     },
-    "w": 14.7
+      "w": 14.7,
+      "canEvolve": true,
   },
   "Hydreigon": {
     "t1": "Dark",
@@ -7500,7 +8009,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 105,
       "sp": 60
     },
-    "w": 135.0
+      "w": 135.0,
+      "ab": "Water Absorb",
   },
   "Joltik": {
     "t1": "Bug",
@@ -7513,7 +8023,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 65
     },
-    "w": 0.6
+      "w": 0.6,
+      "canEvolve": true,
   },
   "Karrablast": {
     "t1": "Bug",
@@ -7525,7 +8036,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 60
     },
-    "w": 5.9
+      "w": 5.9,
+      "canEvolve": true,
   },
   "Keldeo": {
     "t1": "Water",
@@ -7551,7 +8063,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 50
     },
-    "w": 51.0
+      "w": 51.0,
+      "canEvolve": true,
   },
   "Klink": {
     "t1": "Steel",
@@ -7563,7 +8076,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 30
     },
-    "w": 21.0
+      "w": 21.0,
+      "canEvolve": true,
   },
   "Klinklang": {
     "t1": "Steel",
@@ -7575,7 +8089,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 90
     },
-    "w": 81.0
+      "w": 81.0,
+      "ab": "Clear Body",
   },
   "Krokorok": {
     "t1": "Ground",
@@ -7588,7 +8103,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 74
     },
-    "w": 33.4
+      "w": 33.4,
+      "canEvolve": true,
   },
   "Krookodile": {
     "t1": "Ground",
@@ -7601,7 +8117,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 92
     },
-    "w": 96.3
+      "w": 96.3,
+      "ab": "Intimidate",
   },
   "Kyurem": {
     "t1": "Dragon",
@@ -7656,7 +8173,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 55
     },
-    "w": 13.0
+      "w": 13.0,
+      "canEvolve": true,
   },
   "Landorus": {
     "t1": "Ground",
@@ -7669,7 +8187,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 101
     },
-    "w": 68.0
+      "w": 68.0,
+      "ab": "Sand Force",
   },
   "Landorus-Therian": {
     "t1": "Ground",
@@ -7696,7 +8215,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 60
     },
-    "w": 28.8
+      "w": 28.8,
+      "canEvolve": true,
   },
   "Leavanny": {
     "t1": "Bug",
@@ -7721,7 +8241,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 106
     },
-    "w": 37.5
+      "w": 37.5,
+      "ab": "Prankster",
   },
   "Lilligant": {
     "t1": "Grass",
@@ -7733,7 +8254,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 90
     },
-    "w": 16.3
+      "w": 16.3,
+      "ab": "Chlorophyll",
   },
   "Lillipup": {
     "t1": "Normal",
@@ -7745,7 +8267,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 55
     },
-    "w": 4.1
+      "w": 4.1,
+      "canEvolve": true,
   },
   "Litwick": {
     "t1": "Ghost",
@@ -7758,7 +8281,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 20
     },
-    "w": 3.1
+      "w": 3.1,
+      "canEvolve": true,
   },
   "Mandibuzz": {
     "t1": "Dark",
@@ -7771,7 +8295,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 95,
       "sp": 80
     },
-    "w": 39.5
+      "w": 39.5,
+      "ab": "Overcoat",
   },
   "Maractus": {
     "t1": "Grass",
@@ -7783,7 +8308,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 67,
       "sp": 60
     },
-    "w": 28.0
+      "w": 28.0,
+      "ab": "Chlorophyll",
   },
   "Meloetta": {
     "t1": "Normal",
@@ -7828,7 +8354,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 65
     },
-    "w": 20.0
+      "w": 20.0,
+      "canEvolve": true,
   },
   "Mienshao": {
     "t1": "Fighting",
@@ -7840,7 +8367,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 105
     },
-    "w": 35.5
+      "w": 35.5,
+      "ab": "Inner Focus",
   },
   "Minccino": {
     "t1": "Normal",
@@ -7852,7 +8380,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 75
     },
-    "w": 5.8
+      "w": 5.8,
+      "canEvolve": true,
   },
   "Munna": {
     "t1": "Psychic",
@@ -7864,7 +8393,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 24
     },
-    "w": 23.3
+      "w": 23.3,
+      "canEvolve": true,
   },
   "Musharna": {
     "t1": "Psychic",
@@ -7876,7 +8406,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 95,
       "sp": 29
     },
-    "w": 60.5
+      "w": 60.5,
+      "ab": "Telepathy",
   },
   "Oshawott": {
     "t1": "Water",
@@ -7889,7 +8420,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 45
     },
     "w": 5.9,
-    "ab": "Torrent"
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Palpitoad": {
     "t1": "Water",
@@ -7902,7 +8434,9 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 69
     },
-    "w": 17.0
+      "w": 17.0,
+      "ab": "Swift Swim",
+      "canEvolve": true,
   },
   "Panpour": {
     "t1": "Water",
@@ -7914,7 +8448,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 48,
       "sp": 64
     },
-    "w": 13.5
+      "w": 13.5,
+      "canEvolve": true,
   },
   "Pansage": {
     "t1": "Grass",
@@ -7938,7 +8473,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 48,
       "sp": 64
     },
-    "w": 11.0
+      "w": 11.0,
+      "canEvolve": true,
   },
   "Patrat": {
     "t1": "Normal",
@@ -7950,7 +8486,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 39,
       "sp": 42
     },
-    "w": 11.6
+      "w": 11.6,
+      "canEvolve": true,
   },
   "Pawniard": {
     "t1": "Dark",
@@ -7963,7 +8500,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 60
     },
-    "w": 10.2
+      "w": 10.2,
+      "canEvolve": true,
   },
   "Petilil": {
     "t1": "Grass",
@@ -7975,7 +8513,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 30
     },
-    "w": 6.6
+      "w": 6.6,
+      "canEvolve": true,
   },
   "Pidove": {
     "t1": "Normal",
@@ -7988,7 +8527,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 30,
       "sp": 43
     },
-    "w": 2.1
+      "w": 2.1,
+      "canEvolve": true,
   },
   "Pignite": {
     "t1": "Fire",
@@ -8002,7 +8542,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 55
     },
     "w": 55.5,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Purrloin": {
     "t1": "Dark",
@@ -8014,7 +8555,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 37,
       "sp": 66
     },
-    "w": 10.1
+      "w": 10.1,
+      "canEvolve": true,
   },
   "Reshiram": {
     "t1": "Dragon",
@@ -8040,7 +8582,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 30
     },
-    "w": 20.1
+      "w": 20.1,
+      "ab": "Magic Guard",
   },
   "Roggenrola": {
     "t1": "Rock",
@@ -8052,7 +8595,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 25,
       "sp": 15
     },
-    "w": 18.0
+      "w": 18.0,
+      "canEvolve": true,
   },
   "Rufflet": {
     "t1": "Normal",
@@ -8065,7 +8609,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 60
     },
-    "w": 10.5
+      "w": 10.5,
+      "canEvolve": true,
   },
   "Samurott": {
     "t1": "Water",
@@ -8091,7 +8636,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 35,
       "sp": 65
     },
-    "w": 15.2
+      "w": 15.2,
+      "canEvolve": true,
   },
   "Sawk": {
     "t1": "Fighting",
@@ -8103,7 +8649,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 85
     },
-    "w": 51.0
+      "w": 51.0,
+      "ab": "Sturdy",
   },
   "Sawsbuck": {
     "t1": "Normal",
@@ -8116,7 +8663,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 95
     },
-    "w": 92.5
+      "w": 92.5,
+      "ab": "Sap Sipper",
   },
   "Scolipede": {
     "t1": "Bug",
@@ -8142,7 +8690,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 115,
       "sp": 58
     },
-    "w": 30.0
+      "w": 30.0,
+      "ab": "Intimidate",
   },
   "Scraggy": {
     "t1": "Dark",
@@ -8155,7 +8704,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 70,
       "sp": 48
     },
-    "w": 11.8
+      "w": 11.8,
+      "canEvolve": true,
   },
   "Seismitoad": {
     "t1": "Water",
@@ -8168,7 +8718,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 74
     },
-    "w": 62.0
+      "w": 62.0,
+      "ab": "Water Absorb",
   },
   "Serperior": {
     "t1": "Grass",
@@ -8194,7 +8745,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 83
     },
     "w": 16.0,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Sewaddle": {
     "t1": "Bug",
@@ -8207,7 +8759,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 42
     },
-    "w": 2.5
+      "w": 2.5,
+      "canEvolve": true,
   },
   "Shelmet": {
     "t1": "Bug",
@@ -8219,7 +8772,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 25
     },
-    "w": 7.7
+      "w": 7.7,
+      "canEvolve": true,
   },
   "Sigilyph": {
     "t1": "Psychic",
@@ -8232,7 +8786,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 97
     },
-    "w": 14.0
+      "w": 14.0,
+      "ab": "Wonder Skin",
   },
   "Simipour": {
     "t1": "Water",
@@ -8281,7 +8836,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 63
     },
     "w": 8.1,
-    "ab": "Overgrow"
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Solosis": {
     "t1": "Psychic",
@@ -8293,7 +8849,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 50,
       "sp": 20
     },
-    "w": 1.0
+      "w": 1.0,
+      "canEvolve": true,
   },
   "Stoutland": {
     "t1": "Normal",
@@ -8305,7 +8862,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 90,
       "sp": 80
     },
-    "w": 61.0
+      "w": 61.0,
+      "ab": "Intimidate",
   },
   "Stunfisk": {
     "t1": "Ground",
@@ -8331,7 +8889,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 42
     },
-    "w": 7.3
+      "w": 7.3,
+      "canEvolve": true,
   },
   "Swanna": {
     "t1": "Water",
@@ -8357,7 +8916,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 55,
       "sp": 114
     },
-    "w": 10.5
+      "w": 10.5,
+      "ab": "Simple",
   },
   "Tepig": {
     "t1": "Fire",
@@ -8370,7 +8930,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 45
     },
     "w": 9.9,
-    "ab": "Blaze"
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Terrakion": {
     "t1": "Rock",
@@ -8396,7 +8957,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 85,
       "sp": 45
     },
-    "w": 55.5
+      "w": 55.5,
+      "ab": "Inner Focus",
   },
   "Thundurus": {
     "t1": "Electric",
@@ -8409,7 +8971,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 111
     },
-    "w": 61.0
+      "w": 61.0,
+      "ab": "Prankster",
     },
   "Thundurus-Therian": {
     "t1": "Electric",
@@ -8435,7 +8998,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 35,
       "sp": 35
     },
-    "w": 12.5
+      "w": 12.5,
+      "canEvolve": true,
   },
   "Tirtouga": {
     "t1": "Water",
@@ -8448,7 +9012,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 45,
       "sp": 22
     },
-    "w": 16.5
+      "w": 16.5,
+      "canEvolve": true,
   },
   "Tornadus": {
     "t1": "Flying",
@@ -8460,7 +9025,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 80,
       "sp": 111
     },
-    "w": 63.0
+      "w": 63.0,
+      "ab": "Defiant",
   },
   "Tornadus-Therian": {
     "t1": "Flying",
@@ -8486,7 +9052,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 42,
       "sp": 65
     },
-    "w": 15.0
+      "w": 15.0,
+      "canEvolve": true,
   },
   "Trubbish": {
     "t1": "Poison",
@@ -8498,7 +9065,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 62,
       "sp": 65
     },
-    "w": 31.0
+      "w": 31.0,
+      "canEvolve": true,
   },
   "Tympole": {
     "t1": "Water",
@@ -8510,7 +9078,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 40,
       "sp": 64
     },
-    "w": 4.5
+      "w": 4.5,
+      "canEvolve": true,
   },
   "Tynamo": {
     "t1": "Electric",
@@ -8523,7 +9092,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 60
     },
     "w": 0.3,
-    "ab": "Levitate"
+      "ab": "Levitate",
+      "canEvolve": true,
   },
   "Unfezant": {
     "t1": "Normal",
@@ -8548,7 +9118,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 59
     },
-    "w": 41.0
+      "w": 41.0,
+      "canEvolve": true,
   },
   "Vanillite": {
     "t1": "Ice",
@@ -8560,7 +9131,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 60,
       "sp": 44
     },
-    "w": 5.7
+      "w": 5.7,
+      "canEvolve": true,
   },
   "Vanilluxe": {
     "t1": "Ice",
@@ -8585,7 +9157,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 39,
       "sp": 57
     },
-    "w": 5.3
+      "w": 5.3,
+      "canEvolve": true,
   },
   "Victini": {
     "t1": "Psychic",
@@ -8626,7 +9199,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 105,
       "sp": 100
     },
-    "w": 46.0
+      "w": 46.0,
+      "ab": "Flame Body",
   },
   "Vullaby": {
     "t1": "Dark",
@@ -8639,7 +9213,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 65,
       "sp": 60
     },
-    "w": 9.0
+      "w": 9.0,
+      "canEvolve": true,
   },
   "Watchog": {
     "t1": "Normal",
@@ -8663,7 +9238,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 75,
       "sp": 116
     },
-    "w": 6.6
+      "w": 6.6,
+      "ab": "Prankster",
   },
   "Whirlipede": {
     "t1": "Bug",
@@ -8676,7 +9252,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 79,
       "sp": 47
     },
-    "w": 58.5
+      "w": 58.5,
+      "canEvolve": true,
   },
   "Woobat": {
     "t1": "Psychic",
@@ -8689,7 +9266,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 43,
       "sp": 72
     },
-    "w": 2.1
+      "w": 2.1,
+      "canEvolve": true,
   },
   "Yamask": {
     "t1": "Ghost",
@@ -8702,7 +9280,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 30
     },
     "w": 1.5,
-    "ab": "Mummy"
+      "ab": "Mummy",
+      "canEvolve": true,
   },
   "Zebstrika": {
     "t1": "Electric",
@@ -8714,7 +9293,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sd": 63,
       "sp": 116
     },
-    "w": 79.5
+      "w": 79.5,
+      "ab": "Lightning Rod",
   },
   "Zekrom": {
     "t1": "Dragon",
@@ -8754,7 +9334,8 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 65
     },
     "w": 12.5,
-    "ab": "Illusion"
+      "ab": "Illusion",
+      "canEvolve": true,
   },
   "Zweilous": {
     "t1": "Dark",
@@ -8768,8 +9349,58 @@ var POKEDEX_BW = $.extend(true, {}, POKEDEX_DPP, {
       "sp": 58
     },
     "w": 50.0,
-    "ab": "Hustle"
-  }
+      "ab": "Hustle",
+      "canEvolve": true,
+    },
+  //ABILITY ADJUSTMENTS
+    "Pikachu": { "ab": "Lightning Rod", },
+    "Raichu": { "ab": "Lightning Rod", },
+    "Nidoqueen": { "ab": "Sheer Force", },
+    "Nidoking": { "ab": "Sheer Force", },
+    "Clefairy": { "ab": "Friend Guard", },
+    "Clefable": { "ab": "Unaware", },
+    "Ninetales": { "ab": "Drought", },
+    "Primeape": { "ab": "Defiant", },
+    "Poliwrath": { "ab": "Swift Swim", },
+    "Politoed": { "ab": "Drizzle", },
+    "Alakazam": { "ab": "Magic Guard", },
+    "Golem": { "ab": "Sturdy", },
+    "Magnezone": { "ab": "Sturdy", },
+    "Steelix": { "ab": "Sheer Force", },
+    "Kingler": { "ab": "Sheer Force", },
+    "Exeggutor": { "ab": "Harvest", },
+    "Lickilicky": { "ab": "Cloud Nine", },
+    "Tangrowth": { "ab": "Regenerator", },
+    "Seaking": { "ab": "Lightning Rod", },
+    "Jynx": { "ab": "Dry Skin", },
+    "Ditto": { "ab": "Imposter", },
+    "Espeon": { "ab": "Magic Bounce", },
+    "Umbreon": { "ab": "Inner Focus", },
+    "Leafeon": { "ab": "Chlorophyll", },
+    "Aerodactyl": { "ab": "Unnerve", },
+    "Snorlax": { "ab": "Gluttony", },
+    "Dragonite": { "ab": "Multiscale", },
+    "Xatu": { "ab": "Magic Bounce", },
+    "Quagsire": { "ab": "Unaware", },
+    "Murkrow": { "ab": "Prankster", },
+    "Mamoswine": { "ab": "Thick Fat", },
+    "Octillery": { "ab": "Moody", },
+    "Blaziken": { "ab": "Speed Boost", },
+    "Swellow": { "ab": "Scrappy", },
+    "Breloom": { "ab": "Technician", },
+    "Exploud": { "ab": "Scrappy", },
+    "Volbeat": { "ab": "Prankster", },
+    "Illumise": { "ab": "Prankster", },
+    "Zangoose": { "ab": "Toxic Boost", },
+    "Crawdaunt": { "ab": "Adaptability", },
+    "Cradily": { "ab": "Storm Drain", },
+    "Armaldo": { "ab": "Swift Swim", },
+    "Glalie": { "ab": "Moody", },
+    "Rampardos": { "ab": "Sheer Force", },
+    "Pachirisu": { "ab": "Volt Absorb", },
+    "Purugly": { "ab": "Defiant", },
+    "Garchomp": { "ab": "Rough Skin", },
+    "Riolu": { "ab": "Prankster", },
 });
 
 var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
@@ -8862,6 +9493,7 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
   "Cottonee": { "t2": "Fairy" },
   "Whimsicott": { "t2": "Fairy" },
   "Krookodile": { "bs": { "df": 80 } },
+
   "Aegislash": {
     "t1": "Steel",
     "t2": "Ghost",
@@ -8918,7 +9550,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sp": 46
     },
     "w": 25.2,
-    "ab": "Refrigerate"
+      "ab": "Refrigerate",
+      "canEvolve": true,
   },
   "Aromatisse": {
     "t1": "Fairy",
@@ -8930,7 +9563,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 89,
       "sp": 29
     },
-    "w": 15.5
+      "w": 15.5,
+      "ab": "Healer",
   },
   "Aurorus": {
     "t1": "Rock",
@@ -8956,7 +9590,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 46,
       "sp": 28
     },
-    "w": 505.0
+      "w": 505.0,
+      "ab": "Own Tempo",
   },
   "Barbaracle": {
     "t1": "Rock",
@@ -8969,7 +9604,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 86,
       "sp": 68
     },
-    "w": 96.0
+      "w": 96.0,
+      "ab": "Tough Claws",
   },
   "Bergmite": {
     "t1": "Ice",
@@ -8981,7 +9617,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 35,
       "sp": 28
     },
-    "w": 99.5
+      "w": 99.5,
+      "canEvolve": true,
   },
   "Binacle": {
     "t1": "Rock",
@@ -8994,7 +9631,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 56,
       "sp": 50
     },
-    "w": 31.0
+      "w": 31.0,
+      "canEvolve": true,
   },
   "Braixen": {
     "t1": "Fire",
@@ -9006,7 +9644,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 70,
       "sp": 73
     },
-    "w": 14.5
+      "w": 14.5,
+      "canEvolve": true,
   },
   "Bunnelby": {
     "t1": "Normal",
@@ -9018,7 +9657,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 36,
       "sp": 57
     },
-    "w": 5.0
+      "w": 5.0,
+      "canEvolve": true,
   },
   "Carbink": {
     "t1": "Rock",
@@ -9031,7 +9671,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 150,
       "sp": 50
     },
-    "w": 5.7
+      "w": 5.7,
+      "ab": "Sturdy",
   },
   "Chesnaught": {
     "t1": "Grass",
@@ -9044,7 +9685,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 64
     },
-    "w": 90.0
+      "w": 90.0,
+      "ab": "Bulletproof",
   },
   "Chespin": {
     "t1": "Grass",
@@ -9056,7 +9698,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 45,
       "sp": 38
     },
-    "w": 9.0
+      "w": 9.0,
+      "canEvolve": true,
   },
   "Clauncher": {
     "t1": "Water",
@@ -9069,7 +9712,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sp": 44
     },
     "w": 8.3,
-    "ab": "Mega Launcher"
+      "ab": "Mega Launcher",
+      "canEvolve": true,
   },
   "Clawitzer": {
     "t1": "Water",
@@ -9126,7 +9770,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 100,
       "sp": 104
     },
-    "w": 39.0
+      "w": 39.0,
+      "ab": "Magician",
   },
   "Diggersby": {
     "t1": "Normal",
@@ -9139,7 +9784,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 77,
       "sp": 78
     },
-    "w": 42.4
+      "w": 42.4,
+      "ab": "Huge Power",
   },
   "Doublade": {
     "t1": "Steel",
@@ -9166,7 +9812,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 123,
       "sp": 44
     },
-    "w": 81.5
+      "w": 81.5,
+      "ab": "Adaptability",
   },
   "Espurr": {
     "t1": "Psychic",
@@ -9178,7 +9825,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 60,
       "sp": 68
     },
-    "w": 3.5
+      "w": 3.5,
+      "canEvolve": true,
   },
   "Fennekin": {
     "t1": "Fire",
@@ -9190,7 +9838,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 60,
       "sp": 60
     },
-    "w": 9.4
+      "w": 9.4,
+      "canEvolve": true,
   },
   "Flabebe": {
     "t1": "Fairy",
@@ -9202,7 +9851,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 79,
       "sp": 42
     },
-    "w": 0.1
+      "w": 0.1,
+      "canEvolve": true,
   },
   "Fletchinder": {
     "t1": "Fire",
@@ -9215,7 +9865,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 52,
       "sp": 84
     },
-    "w": 16.0
+      "w": 16.0,
+      "canEvolve": true,
   },
   "Fletchling": {
     "t1": "Normal",
@@ -9228,7 +9879,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 38,
       "sp": 62
     },
-    "w": 1.7
+      "w": 1.7,
+      "canEvolve": true,
   },
   "Floette": {
     "t1": "Fairy",
@@ -9240,7 +9892,9 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 98,
       "sp": 52
     },
-    "w": 0.9
+      "w": 0.9,
+      "ab": "Symbiosis",
+      "canEvolve": true,
   },
   "Floette-Eternal": {
     "t1": "Fairy",
@@ -9265,7 +9919,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 154,
       "sp": 75
     },
-    "w": 10.0
+      "w": 10.0,
+      "ab": "Symbiosis",
   },
   "Froakie": {
     "t1": "Water",
@@ -9277,7 +9932,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 44,
       "sp": 71
     },
-    "w": 7.0
+      "w": 7.0,
+      "canEvolve": true,
   },
   "Frogadier": {
     "t1": "Water",
@@ -9289,7 +9945,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 56,
       "sp": 97
     },
-    "w": 10.9
+      "w": 10.9,
+      "canEvolve": true,
   },
   "Furfrou": {
     "t1": "Normal",
@@ -9314,7 +9971,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 81,
       "sp": 68
     },
-    "w": 91.0
+      "w": 91.0,
+      "ab": "Sap Sipper",
   },
   "Goodra": {
     "t1": "Dragon",
@@ -9326,7 +9984,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 150,
       "sp": 80
     },
-    "w": 150.5
+      "w": 150.5,
+      "ab": "Sap Sipper",
   },
   "Goomy": {
     "t1": "Dragon",
@@ -9338,7 +9997,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 40
     },
-    "w": 2.8
+      "w": 2.8,
+      "canEvolve": true,
   },
   "Gourgeist-Average": {
     "t1": "Ghost",
@@ -9351,7 +10011,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 84
     },
-    "w": 12.5
+      "w": 12.5,
+      "ab": "Frisk",
   },
   "Gourgeist-Large": {
     "t1": "Ghost",
@@ -9364,7 +10025,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 69
     },
-    "w": 14.0
+      "w": 14.0,
+      "ab": "Frisk",
   },
   "Gourgeist-Small": {
     "t1": "Ghost",
@@ -9377,7 +10039,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 99
     },
-    "w": 9.5
+      "w": 9.5,
+      "ab": "Frisk",
   },
   "Gourgeist-Super": {
     "t1": "Ghost",
@@ -9390,7 +10053,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 54
     },
-    "w": 39.0
+      "w": 39.0,
+      "ab": "Insomnia",
   },
   "Greninja": {
     "t1": "Water",
@@ -9417,7 +10081,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 63,
       "sp": 118
     },
-    "w": 21.5
+      "w": 21.5,
+      "ab": "Unburden",
   },
   "Heliolisk": {
     "t1": "Electric",
@@ -9430,7 +10095,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 94,
       "sp": 109
     },
-    "w": 21.0
+      "w": 21.0,
+      "ab": "Dry Skin",
   },
   "Helioptile": {
     "t1": "Electric",
@@ -9443,7 +10109,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 43,
       "sp": 70
     },
-    "w": 6.0
+      "w": 6.0,
+      "canEvolve": true,
   },
   "Honedge": {
     "t1": "Steel",
@@ -9457,7 +10124,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sp": 28
     },
     "w": 2.0,
-    "ab": "No Guard"
+      "ab": "No Guard",
+      "canEvolve": true,
   },
   "Hoopa": {
     "t1": "Psychic",
@@ -9498,7 +10166,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 46,
       "sp": 45
     },
-    "w": 3.5
+      "w": 3.5,
+      "canEvolve": true,
   },
   "Klefki": {
     "t1": "Steel",
@@ -9511,7 +10180,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 87,
       "sp": 75
     },
-    "w": 3.0
+      "w": 3.0,
+      "ab": "Prankster",
   },
   "Litleo": {
     "t1": "Fire",
@@ -9524,7 +10194,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 54,
       "sp": 72
     },
-    "w": 13.5
+      "w": 13.5,
+      "canEvolve": true,
   },
   "Malamar": {
     "t1": "Dark",
@@ -9537,7 +10208,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 73
     },
-    "w": 47.0
+      "w": 47.0,
+      "ab": "Contrary",
   },
   "Mega Abomasnow": {
     "t1": "Grass",
@@ -10260,7 +10932,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 81,
       "sp": 104
     },
-    "w": 8.5
+      "w": 8.5,
+      "ab": "Prankster",
   },
   "Noibat": {
     "t1": "Flying",
@@ -10273,7 +10946,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 40,
       "sp": 55
     },
-    "w": 8.0
+      "w": 8.0,
+      "canEvolve": true,
   },
   "Noivern": {
     "t1": "Flying",
@@ -10286,7 +10960,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 80,
       "sp": 123
     },
-    "w": 85.0
+      "w": 85.0,
+      "ab": "Infiltrator",
   },
   "Pancham": {
     "t1": "Fighting",
@@ -10298,7 +10973,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 48,
       "sp": 43
     },
-    "w": 8.0
+      "w": 8.0,
+      "canEvolve": true,
   },
   "Pangoro": {
     "t1": "Fighting",
@@ -10311,7 +10987,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 71,
       "sp": 58
     },
-    "w": 136.0
+      "w": 136.0,
+      "ab": "Scrappy",
   },
   "Phantump": {
     "t1": "Ghost",
@@ -10324,7 +11001,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 60,
       "sp": 38
     },
-    "w": 7.0
+      "w": 7.0,
+      "canEvolve": true,
   },
   "Primal Groudon": {
     "t1": "Ground",
@@ -10364,7 +11042,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 55,
       "sp": 51
     },
-    "w": 5.0
+      "w": 5.0,
+      "canEvolve": true,
   },
   "Pumpkaboo-Large": {
     "t1": "Ghost",
@@ -10377,7 +11056,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 55,
       "sp": 46
     },
-    "w": 7.5
+      "w": 7.5,
+      "canEvolve": true,
   },
   "Pumpkaboo-Small": {
     "t1": "Ghost",
@@ -10390,7 +11070,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 55,
       "sp": 56
     },
-    "w": 3.5
+      "w": 3.5,
+      "canEvolve": true,
   },
   "Pumpkaboo-Super": {
     "t1": "Ghost",
@@ -10403,7 +11084,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 55,
       "sp": 41
     },
-    "w": 15.0
+      "w": 15.0,
+      "canEvolve": true,
   },
   "Pyroar": {
     "t1": "Fire",
@@ -10416,7 +11098,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 66,
       "sp": 106
     },
-    "w": 81.5
+      "w": 81.5,
+      "ab": "Unnerve",
   },
   "Quilladin": {
     "t1": "Grass",
@@ -10428,7 +11111,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 58,
       "sp": 57
     },
-    "w": 29.0
+      "w": 29.0,
+      "canEvolve": true,
   },
   "Scatterbug": {
     "t1": "Bug",
@@ -10440,7 +11124,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 25,
       "sp": 35
     },
-    "w": 2.5
+      "w": 2.5,
+      "canEvolve": true,
   },
   "Skiddo": {
     "t1": "Grass",
@@ -10452,7 +11137,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 57,
       "sp": 52
     },
-    "w": 31.0
+      "w": 31.0,
+      "canEvolve": true,
   },
   "Skrelp": {
     "t1": "Poison",
@@ -10465,7 +11151,9 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 60,
       "sp": 30
     },
-    "w": 7.3
+      "w": 7.3,
+      "ab": "Adaptability",
+      "canEvolve": true,
   },
   "Sliggoo": {
     "t1": "Dragon",
@@ -10477,7 +11165,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 113,
       "sp": 60
     },
-    "w": 17.5
+      "w": 17.5,
+      "canEvolve": true,
   },
   "Slurpuff": {
     "t1": "Fairy",
@@ -10489,7 +11178,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 75,
       "sp": 72
     },
-    "w": 5.0
+      "w": 5.0,
+      "ab": "Unburden",
   },
   "Spewpa": {
     "t1": "Bug",
@@ -10501,7 +11191,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 30,
       "sp": 29
     },
-    "w": 8.4
+      "w": 8.4,
+      "canEvolve": true,
   },
   "Spritzee": {
     "t1": "Fairy",
@@ -10513,7 +11204,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 65,
       "sp": 23
     },
-    "w": 0.5
+      "w": 0.5,
+      "canEvolve": true,
   },
   "Swirlix": {
     "t1": "Fairy",
@@ -10525,7 +11217,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 57,
       "sp": 49
     },
-    "w": 3.5
+      "w": 3.5,
+      "canEvolve": true,
   },
   "Sylveon": {
     "t1": "Fairy",
@@ -10537,7 +11230,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 130,
       "sp": 60
     },
-    "w": 23.5
+      "w": 23.5,
+      "ab": "Pixilate",
   },
   "Talonflame": {
     "t1": "Fire",
@@ -10550,7 +11244,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 69,
       "sp": 126
     },
-    "w": 24.5
+      "w": 24.5,
+      "ab": "Gale Wings",
   },
   "Trevenant": {
     "t1": "Ghost",
@@ -10563,7 +11258,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 82,
       "sp": 56
     },
-    "w": 71.0
+      "w": 71.0,
+      "ab": "Harvest",
   },
   "Tyrantrum": {
     "t1": "Rock",
@@ -10591,7 +11287,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sp": 48
     },
     "w": 26.0,
-    "ab": "Strong Jaw"
+      "ab": "Strong Jaw",
+      "canEvolve": true,
   },
   "Vivillon": {
     "t1": "Bug",
@@ -10604,7 +11301,8 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sd": 50,
       "sp": 89
     },
-    "w": 17.0
+      "w": 17.0,
+      "ab": "Friend Guard",
   },
   "Volcanion": {
     "t1": "Fire",
@@ -10659,9 +11357,72 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
       "sp": 95
     },
     "w": 305.0,
-    "ab": "Power Construct",
-    "formes": ["Zygarde 50%", "Zygarde Complete", "Zygarde 10%"]
+    "ab": "Aura Break",
   },
+    "Milotic": { "ab": "Competitive" },
+    "Wigglytuff": { "ab": "Competitive", },
+    "Kecleon": { "ab": "Protean", },
+    "Dusclops": { "ab": "Frisk", },
+    "Dusknoir": { "ab": "Frisk", },
+    "Scolipede": { "ab": "Speed Boost", },
+});
+
+var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
+
+
+
+  //new forms
+  "Greninja": { "formes": ["Greninja", "Ash-Greninja"] },
+  "Zygarde": { "formes": ["Zygarde 50%", "Zygarde Complete", "Zygarde 10%"] },
+
+  //abilities
+  "Pelipper": { "bs": { "sa": 95 }, "ab": "Drizzle"},
+  "Torkoal": {"ab": "Drought"},
+  "Gengar": {"ab": "Cursed Body"},
+    "Venusaur": { "ab": "Chlorophyll" },
+    "Vanilluxe": { "ab": "Snow Warning", },
+    "Gigalith": { "ab": "Sand Stream", },
+
+  //hp buffs
+  "Magcargo": { "bs": { "hp": 60, "sa": 90 } },
+  "Corsola": { "bs": { "hp": 65, "df": 95, "sd": 95 } },
+  "Mantine": { "bs": { "hp": 85 } },
+  "Lunatone": { "bs": { "hp": 90 } },
+  "Solrock": { "bs": { "hp": 90 } },
+  "Chimecho": { "bs": { "hp": 75, "df": 80, "sd": 90 } },
+  "Woobat": { "bs": { "hp": 65 } },
+  "Cryogonal": { "bs": { "hp": 80, "df": 50 } },
+
+  //attack buffs
+  "Dugtrio": { "bs": { "at": 100 }},
+  "Arbok": { "bs": { "at": 95 } },
+  "Farfetch\u0027d": { "bs": { "at": 90 } },
+  "Crustle": { "bs": { "at": 105 } },
+  "Beartic": { "bs": { "at": 130 } },
+
+  //defense buffs
+  "Qwilfish": { "bs": { "df": 85 } },
+  "Volbeat": { "bs": { "df": 75, "sd": 85 } },
+  "Illumise": { "bs": { "df": 75, "sd": 85 } },
+
+  //special attack buffs
+  "Noctowl": { "bs": { "sa": 86 } },
+  "Swellow": { "bs": { "sa": 75 } },
+
+  //special defense buffs
+  "Exeggutor": { "bs": { "sd": 75 }},
+  "Ariados": { "bs": { "sd": 70 } },
+
+  //speed buffs
+  "Dodrio": { "bs": { "sp": 110 } },
+  "Electrode": { "bs": { "sp": 150 } },
+  "Delcatty": { "bs": { "sp": 90 } },
+  "Masquerain": { "bs": { "sp": 80, "sa": 100 } },
+
+  //alakazam buff because i think they made the mega's stats last gen before they buffed non-mega alakazam
+  "Mega Alakazam": { "bs": { "sd": 105} },
+
+  //and here's the dex!
   "Zygarde 50%": {
     "t1": "Dragon",
     "t2": "Ground",
@@ -10707,73 +11468,6 @@ var POKEDEX_XY = $.extend(true, {}, POKEDEX_BW, {
     "ab": "Power Construct",
     "isAlternateForme": true
   },
-  "Milotic": { "ab": "Competitive" }
-});
-
-delete POKEDEX_XY['Duskull'].ab;
-delete POKEDEX_XY['Snivy'].ab;
-delete POKEDEX_XY['Servine'].ab;
-delete POKEDEX_XY['Serperior'].ab;
-delete POKEDEX_XY['Tepig'].ab;
-delete POKEDEX_XY['Pignite'].ab;
-delete POKEDEX_XY['Emboar'].ab;
-delete POKEDEX_XY['Oshawott'].ab;
-delete POKEDEX_XY['Dewott'].ab;
-delete POKEDEX_XY['Samurott'].ab;
-
-var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
-
-
-
-  //new forms
-  "Greninja": { "formes": ["Greninja", "Ash-Greninja"] },
-
-  //abilities
-  "Pelipper": { "bs": { "sa": 95 }, "ab": "Drizzle"},
-  "Torkoal": {"ab": "Drought"},
-  "Gengar": {"ab": "Cursed Body"},
-  "Venusaur": {"ab": "Chlorophyll"},
-
-  //hp buffs
-  "Magcargo": { "bs": { "hp": 60, "sa": 90 } },
-  "Corsola": { "bs": { "hp": 65, "df": 95, "sd": 95 } },
-  "Mantine": { "bs": { "hp": 85 } },
-  "Lunatone": { "bs": { "hp": 90 } },
-  "Solrock": { "bs": { "hp": 90 } },
-  "Chimecho": { "bs": { "hp": 75, "df": 80, "sd": 90 } },
-  "Woobat": { "bs": { "hp": 65 } },
-  "Cryogonal": { "bs": { "hp": 80, "df": 50 } },
-
-  //attack buffs
-  "Dugtrio": { "bs": { "at": 100 }},
-  "Arbok": { "bs": { "at": 95 } },
-  "Farfetch\u0027d": { "bs": { "at": 90 } },
-  "Crustle": { "bs": { "at": 105 } },
-  "Beartic": { "bs": { "at": 130 } },
-
-  //defense buffs
-  "Qwilfish": { "bs": { "df": 85 } },
-  "Volbeat": { "bs": { "df": 75, "sd": 85 } },
-  "Illumise": { "bs": { "df": 75, "sd": 85 } },
-
-  //special attack buffs
-  "Noctowl": { "bs": { "sa": 86 } },
-  "Swellow": { "bs": { "sa": 75 } },
-
-  //special defense buffs
-  "Exeggutor": { "bs": { "sd": 75 }},
-  "Ariados": { "bs": { "sd": 70 } },
-
-  //speed buffs
-  "Dodrio": { "bs": { "sp": 110 } },
-  "Electrode": { "bs": { "sp": 150 } },
-  "Delcatty": { "bs": { "sp": 90 } },
-  "Masquerain": { "bs": { "sp": 80, "sa": 100 } },
-
-  //alakazam buff because he's a special snowflake
-  "Mega Alakazam": { "bs": { "sd": 105} },
-
-  //and here's the dex!
   "Ash-Greninja": {
     "t1": "Water",
     "t2": "Dark",
@@ -10800,7 +11494,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 35,
       "sp": 72
     },
-    "w": 3.8,
+      "w": 3.8,
+      "canEvolve": true,
   },
   "Raticate-Alola": {
     "t1": "Dark",
@@ -10813,7 +11508,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 80,
       "sp": 77
     },
-    "w": 25.5,
+      "w": 25.5,
+      "ab": "Thick Fat",
   },
   "Meowth-Alola": {
     "t1": "Dark",
@@ -10825,7 +11521,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 40,
       "sp": 90
     },
-    "w": 4.2,
+      "w": 4.2,
+      "canEvolve": true,
   },
   "Persian-Alola": {
     "t1": "Dark",
@@ -10837,7 +11534,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 65,
       "sp": 115
     },
-    "w": 33.0,
+      "w": 33.0,
+      "ab": "Fur Coat",
   },
   "Raichu-Alola": {
     "t1": "Electric",
@@ -10850,7 +11548,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 85,
       "sp": 110
     },
-    "w": 21.0,
+      "w": 21.0,
+      "ab": "Surge Surfer",
   },
   "Marowak-Alola": {
     "t1": "Fire",
@@ -10863,7 +11562,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 80,
       "sp": 45
     },
-    "w": 34.0,
+      "w": 34.0,
+      "ab": "Lightning Rod",
   },
   "Geodude-Alola": {
     "t1": "Rock",
@@ -10876,7 +11576,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 30,
       "sp": 20
     },
-    "w": 20.3,
+      "w": 20.3,
+      "canEvolve": true,
   },
   "Graveler-Alola": {
     "t1": "Rock",
@@ -10889,7 +11590,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 45,
       "sp": 35
     },
-    "w": 110.0,
+      "w": 110.0,
+      "canEvolve": true,
   },
   "Golem-Alola": {
     "t1": "Rock",
@@ -10916,7 +11618,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 45
     },
-    "w": 415.6,
+      "w": 415.6,
+      "ab": "Harvest",
   },
   "Diglett-Alola": {
     "t1": "Ground",
@@ -10929,7 +11632,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 45,
       "sp": 90
     },
-    "w": 1.0,
+      "w": 1.0,
+      "canEvolve": true,
   },
   "Dugtrio-Alola": {
     "t1": "Ground",
@@ -10954,7 +11658,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 65,
       "sp": 65
     },
-    "w": 9.9,
+      "w": 9.9,
+      "canEvolve": true,
   },
   "Ninetales-Alola": {
     "t1": "Ice",
@@ -10981,7 +11686,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 35,
       "sp": 40
     },
-    "w": 40.0,
+      "w": 40.0,
+      "canEvolve": true,
   },
   "Sandslash-Alola": {
     "t1": "Ice",
@@ -10994,7 +11700,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 65,
       "sp": 65
     },
-    "w": 55.0,
+      "w": 55.0,
+      "ab": "Slush Rush",
   },
   "Grimer-Alola": {
     "t1": "Poison",
@@ -11007,7 +11714,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 50,
       "sp": 25
     },
-    "w": 42.0,
+      "w": 42.0,
+      "canEvolve": true,
   },
   "Muk-Alola": {
     "t1": "Poison",
@@ -11020,7 +11728,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 100,
       "sp": 50
     },
-    "w": 52.0,
+      "w": 52.0,
+      "ab": "Gluttony",
   },
   "Rowlet": {
     "t1": "Grass",
@@ -11033,7 +11742,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 50,
       "sp": 42
     },
-    "w": 1.5
+      "w": 1.5,
+      "canEvolve": true,
   },
   "Dartrix": {
     "t1": "Grass",
@@ -11046,7 +11756,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 52
     },
-    "w": 16.0
+      "w": 16.0,
+      "canEvolve": true,
   },
   "Decidueye": {
     "t1": "Grass",
@@ -11071,7 +11782,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 40,
       "sp": 70
     },
-    "w": 4.3
+      "w": 4.3,
+      "canEvolve": true,
   },
   "Torracat": {
     "t1": "Fire",
@@ -11083,7 +11795,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 50,
       "sp": 90
     },
-    "w": 25.0
+      "w": 25.0,
+      "canEvolve": true,
   },
   "Incineroar": {
     "t1": "Fire",
@@ -11096,7 +11809,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 90,
       "sp": 60
     },
-    "w": 83.0
+      "w": 83.0,
+      "ab": "Intimidate",
   },
   "Popplio": {
     "t1": "Water",
@@ -11108,7 +11822,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 56,
       "sp": 40
     },
-    "w": 7.5
+      "w": 7.5,
+      "canEvolve": true,
   },
   "Brionne": {
     "t1": "Water",
@@ -11120,7 +11835,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 81,
       "sp": 50
     },
-    "w": 17.5
+      "w": 17.5,
+      "canEvolve": true,
   },
   "Primarina": {
     "t1": "Water",
@@ -11133,7 +11849,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 116,
       "sp": 60
     },
-    "w": 44.0
+      "w": 44.0,
+      "ab": "Liquid Voice",
   },
   "Pikipek": {
     "t1": "Normal",
@@ -11146,7 +11863,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 30,
       "sp": 65
     },
-    "w": 1.2
+      "w": 1.2,
+      "canEvolve": true,
   },
   "Trumbeak": {
     "t1": "Normal",
@@ -11159,7 +11877,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 50,
       "sp": 75
     },
-    "w": 14.8
+      "w": 14.8,
+      "canEvolve": true,
   },
   "Toucannon": {
     "t1": "Normal",
@@ -11172,7 +11891,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 60
     },
-    "w": 26.0
+      "w": 26.0,
+      "ab": "Skill Link",
   },
   "Yungoos": {
     "t1": "Normal",
@@ -11184,7 +11904,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 30,
       "sp": 45
     },
-    "w": 6.0
+      "w": 6.0,
+      "canEvolve": true,
   },
   "Gumshoos": {
     "t1": "Normal",
@@ -11196,7 +11917,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 60,
       "sp": 45
     },
-    "w": 14.2
+      "w": 14.2,
+      "ab": "Adaptability",
   },
   "Grubbin": {
     "t1": "Bug",
@@ -11208,7 +11930,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 45,
       "sp": 46
     },
-    "w": 4.4
+      "w": 4.4,
+      "canEvolve": true,
   },
   "Charjabug": {
     "t1": "Bug",
@@ -11221,7 +11944,9 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 36
     },
-    "w": 10.5
+      "w": 10.5,
+      "ab": "Battery",
+      "canEvolve": true,
   },
   "Vikavolt": {
     "t1": "Bug",
@@ -11247,7 +11972,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 47,
       "sp": 63
     },
-    "w": 7.0
+      "w": 7.0,
+      "canEvolve": true,
   },
   "Crabominable": {
     "t1": "Fighting",
@@ -11260,9 +11986,10 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 67,
       "sp": 43
     },
-    "w": 180.0
+      "w": 180.0,
+      "ab": "Hyper Cutter",
   },
-  "Oricorio-Fire": {
+  "Oricorio-Baile": {
     "t1": "Fire",
     "t2": "Flying",
     "bs": {
@@ -11273,9 +12000,10 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 93
     },
-    "w": 3.4
+      "w": 3.4,
+      "ab": "Dancer",
   },
-  "Oricorio-Electric": {
+  "Oricorio-Pom-Pom": {
     "t1": "Electric",
     "t2": "Flying",
     "bs": {
@@ -11286,9 +12014,10 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 93
     },
-    "w": 3.4
+      "w": 3.4,
+      "ab": "Dancer",
   },
-  "Oricorio-Psychic": {
+  "Oricorio-Pa'u": {
     "t1": "Psychic",
     "t2": "Flying",
     "bs": {
@@ -11299,9 +12028,10 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 93
     },
-    "w": 3.4
+      "w": 3.4,
+      "ab": "Dancer",
   },
-  "Oricorio-Ghost": {
+  "Oricorio-Sensu": {
     "t1": "Ghost",
     "t2": "Flying",
     "bs": {
@@ -11312,7 +12042,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 93
     },
-    "w": 3.4
+      "w": 3.4,
+      "ab": "Dancer",
   },
   "Cutiefly": {
     "t1": "Bug",
@@ -11325,7 +12056,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 40,
       "sp": 84
     },
-    "w": 0.2
+      "w": 0.2,
+      "canEvolve": true,
   },
   "Ribombee": {
     "t1": "Bug",
@@ -11338,7 +12070,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 124
     },
-    "w": 0.5
+      "w": 0.5,
+      "ab": "Shield Dust",
   },
   "Rockruff": {
     "t1": "Rock",
@@ -11350,7 +12083,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 40,
       "sp": 60
     },
-    "w": 9.2
+      "w": 9.2,
+      "canEvolve": true,
   },
   "Lycanroc-Midday": {
     "t1": "Rock",
@@ -11362,7 +12096,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 65,
       "sp": 112
     },
-    "w": 25.0
+      "w": 25.0,
+      "ab": "Sand Rush",
   },
   "Lycanroc-Midnight": {
     "t1": "Rock",
@@ -11374,7 +12109,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 82
     },
-    "w": 25.0
+      "w": 25.0,
+      "ab": "Vital Spirit",
   },
   "Wishiwashi": {
     "t1": "Water",
@@ -11387,7 +12123,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sp": 30
     },
     "w": 78.6,
-    "formes": ["Wishiwashi-School", "Wishiwashi-Solo"]
+      "formes": ["Wishiwashi-School", "Wishiwashi-Solo"],
+      "ab": "Schooling",
   },
   "Wishiwashi-School": {
     "t1": "Water",
@@ -11399,7 +12136,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 135,
       "sp": 30
     },
-    "w": 78.6,
+      "w": 78.6,
+      "ab": "Schooling",
     "isAlternateForme": true
   },
   "Wishiwashi-Solo": {
@@ -11412,7 +12150,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 25,
       "sp": 40
     },
-    "w": 0.3,
+      "w": 0.3,
+      "ab": "Schooling",
     "isAlternateForme": true
   },
   "Mareanie": {
@@ -11426,7 +12165,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 52,
       "sp": 45
     },
-    "w": 8.0,
+      "w": 8.0,
+      "canEvolve": true,
   },
   "Toxapex": {
     "t1": "Poison",
@@ -11439,7 +12179,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 142,
       "sp": 35
     },
-    "w": 14.5,
+      "w": 14.5,
+      "ab": "Regenerator",
   },
   "Mudbray": {
     "t1": "Ground",
@@ -11451,7 +12192,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 55,
       "sp": 45
     },
-    "w": 110.0,
+      "w": 110.0,
+      "canEvolve": true,
   },
   "Mudsdale": {
     "t1": "Ground",
@@ -11463,7 +12205,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 85,
       "sp": 35
     },
-    "w": 920.0,
+      "w": 920.0,
+      "ab": "Stamina",
   },
   "Dewpider": {
     "t1": "Water",
@@ -11476,7 +12219,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 72,
       "sp": 27
     },
-    "w": 4.0,
+      "w": 4.0,
+      "canEvolve": true,
   },
   "Araquanid": {
     "t1": "Water",
@@ -11502,7 +12246,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 35,
       "sp": 35
     },
-    "w": 1.5,
+      "w": 1.5,
+      "canEvolve": true,
   },
   "Lurantis": {
     "t1": "Grass",
@@ -11514,7 +12259,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 90,
       "sp": 45
     },
-    "w": 19.5,
+      "w": 19.5,
+      "ab": "Contrary",
   },
   "Morelull": {
     "t1": "Grass",
@@ -11527,7 +12273,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 15
     },
-    "w": 1.5,
+      "w": 1.5,
+      "canEvolve": true,
   },
   "Shiinotic": {
     "t1": "Grass",
@@ -11553,7 +12300,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 40,
       "sp": 77
     },
-    "w": 4.8,
+      "w": 4.8,
+      "canEvolve": true,
   },
   "Salazzle": {
     "t1": "Poison",
@@ -11566,7 +12314,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 60,
       "sp": 117
     },
-    "w": 22.2,
+      "w": 22.2,
+      "ab": "Oblivious",
   },
   "Stufful": {
     "t1": "Normal",
@@ -11580,7 +12329,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sp": 50
     },
     "ab": "Fluffy",
-    "w": 6.8,
+      "w": 6.8,
+      "canEvolve": true,
   },
   "Bewear": {
     "t1": "Normal",
@@ -11606,7 +12356,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 38,
       "sp": 32
     },
-    "w": 3.2,
+      "w": 3.2,
+      "canEvolve": true,
   },
   "Steenee": {
     "t1": "Grass",
@@ -11618,7 +12369,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 48,
       "sp": 62
     },
-    "w": 8.2,
+      "w": 8.2,
+      "canEvolve": true,
   },
   "Tsareena": {
     "t1": "Grass",
@@ -11630,7 +12382,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 98,
       "sp": 72
     },
-    "w": 21.4,
+      "w": 21.4,
+      "ab": "Queenly Majesty",
   },
   "Comfey": {
     "t1": "Fairy",
@@ -11642,7 +12395,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 110,
       "sp": 100
     },
-    "w": 0.3,
+      "w": 0.3,
+      "ab": "Triage",
   },
   "Oranguru": {
     "t1": "Normal",
@@ -11655,7 +12409,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 110,
       "sp": 60
     },
-    "w": 76.0,
+      "w": 76.0,
+      "ab": "Inner Focus",
   },
   "Passimian": {
     "t1": "Fighting",
@@ -11667,7 +12422,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 60,
       "sp": 80
     },
-    "w": 82.8,
+      "w": 82.8,
+      "ab": "Defiant",
   },
   "Wimpod": {
     "t1": "Bug",
@@ -11680,7 +12436,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 30,
       "sp": 80
     },
-    "w": 12.0,
+      "w": 12.0,
+      "canEvolve": true,
   },
   "Golisopod": {
     "t1": "Bug",
@@ -11693,7 +12450,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 90,
       "sp": 40
     },
-    "w": 108.0,
+      "w": 108.0,
+      "ab": "Emergency Exit",
   },
   "Sandygast": {
     "t1": "Ghost",
@@ -11706,7 +12464,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 45,
       "sp": 15
     },
-    "w": 70.0,
+      "w": 70.0,
+      "canEvolve": true,
   },
   "Palossand": {
     "t1": "Ghost",
@@ -11719,7 +12478,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 75,
       "sp": 35
     },
-    "w": 250.0,
+      "w": 250.0,
+      "ab": "Water Compaction",
   },
   "Pyukumuku": {
     "t1": "Water",
@@ -11731,7 +12491,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 130,
       "sp": 5
     },
-    "w": 1.2,
+      "w": 1.2,
+      "ab": "Innards Out",
   },
   "Type: Null": {
     "t1": "Normal",
@@ -11743,7 +12504,9 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 95,
       "sp": 59
     },
-    "w": 120.5,
+      "w": 120.5,
+      "ab": "Battle Armor",
+      "canEvolve": true,
   },
   "Silvally": {
     "t1": "Normal",
@@ -11770,7 +12533,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sp": 60
     },
     "w": 40.0,
-    "formes": ["Minior-Up", "Minior-Down"]
+      "formes": ["Minior-Up", "Minior-Down"],
+      "ab": "Shields Down",
   },
   "Minior-Up": {
     "t1": "Rock",
@@ -11783,7 +12547,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 100,
       "sp": 60
     },
-    "w": 40.0,
+      "w": 40.0,
+      "ab": "Shields Down",
     "isAlternateForme": true
   },
   "Minior-Down": {
@@ -11797,7 +12562,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 60,
       "sp": 120
     },
-    "w": 0.3,
+      "w": 0.3,
+      "ab": "Shields Down",
     "isAlternateForme": true
   },
   "Komala": {
@@ -11810,7 +12576,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 95,
       "sp": 65
     },
-    "w": 19.9,
+      "w": 19.9,
+      "ab": "Comatose",
   },
   "Turtonator": {
     "t1": "Fire",
@@ -11823,7 +12590,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 85,
       "sp": 36
     },
-    "w": 212.0,
+      "w": 212.0,
+      "ab": "Shell Armor",
   },
   "Togedemaru": {
     "t1": "Electric",
@@ -11836,7 +12604,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 73,
       "sp": 96
     },
-    "w": 3.3,
+      "w": 3.3,
+      "ab": "Lightning Rod",
   },
   "Mimikyu": {
     "t1": "Ghost",
@@ -11849,20 +12618,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 105,
       "sp": 96
     },
-    "w": 0.7,
-  },
-  "Mimikyu": {
-    "t1": "Ghost",
-    "t2": "Fairy",
-    "bs": {
-      "hp": 55,
-      "at": 90,
-      "df": 80,
-      "sa": 50,
-      "sd": 105,
-      "sp": 96
-    },
-    "w": 0.7,
+      "w": 0.7,
+      "ab": "Disguise",
   },
   "Bruxish": {
     "t1": "Water",
@@ -11875,7 +12632,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 92
     },
-    "w": 19.0,
+      "w": 19.0,
+      "ab": "Dazzling",
   },
   "Drampa": {
     "t1": "Normal",
@@ -11888,7 +12646,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 91,
       "sp": 36
     },
-    "w": 185.0,
+      "w": 185.0,
+      "ab": "Cloud Nine",
   },
   "Dhelmise": {
     "t1": "Ghost",
@@ -11901,7 +12660,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 90,
       "sp": 40
     },
-    "w": 210.0,
+      "w": 210.0,
+      "ab": "Steelworker",
   },
   "Jangmo-o": {
     "t1": "Dragon",
@@ -11913,7 +12673,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 45,
       "sp": 45
     },
-    "w": 29.7,
+      "w": 29.7,
+      "canEvolve": true,
   },
   "Hakamo-o": {
     "t1": "Dragon",
@@ -11926,7 +12687,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 70,
       "sp": 65
     },
-    "w": 47.0,
+      "w": 47.0,
+      "canEvolve": true,
   },
   "Kommo-o": {
     "t1": "Dragon",
@@ -11939,7 +12701,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 105,
       "sp": 85
     },
-    "w": 78.2,
+      "w": 78.2,
+      "ab": "Soundproof",
   },
   "Tapu Koko": {
     "t1": "Electric",
@@ -12007,7 +12770,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 31,
       "sp": 37
     },
-    "w": 0.1,
+      "w": 0.1,
+      "canEvolve": true,
   },
   "Cosmoem": {
     "t1": "Psychic",
@@ -12019,7 +12783,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 131,
       "sp": 37
     },
-    "w": 999.9,
+      "w": 999.9,
+      "canEvolve": true,
   },
   "Solgaleo": {
     "t1": "Psychic",
@@ -12060,7 +12825,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 131,
       "sp": 103
     },
-    "w": 55.5,
+      "w": 55.5,
+      "ab": "Beast Boost",
   },
   "Buzzwole": {
     "t1": "Bug",
@@ -12073,7 +12839,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 53,
       "sp": 79
     },
-    "w": 333.6,
+      "w": 333.6,
+      "ab": "Beast Boost",
   },
   "Pheromosa": {
     "t1": "Bug",
@@ -12086,7 +12853,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 37,
       "sp": 151
     },
-    "w": 25.0,
+      "w": 25.0,
+      "ab": "Beast Boost",
   },
   "Xurkitree": {
     "t1": "Electric",
@@ -12098,7 +12866,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 71,
       "sp": 83
     },
-    "w": 100.0,
+      "w": 100.0,
+      "ab": "Beast Boost",
   },
   "Celesteela": {
     "t1": "Steel",
@@ -12111,7 +12880,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 101,
       "sp": 61
     },
-    "w": 999.9,
+      "w": 999.9,
+      "ab": "Beast Boost",
   },
   "Kartana": {
     "t1": "Grass",
@@ -12124,7 +12894,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 31,
       "sp": 109
     },
-    "w": 0.1,
+      "w": 0.1,
+      "ab": "Beast Boost",
   },
   "Guzzlord": {
     "t1": "Dark",
@@ -12137,7 +12908,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 53,
       "sp": 43
     },
-    "w": 888.0,
+      "w": 888.0,
+      "ab": "Beast Boost",
   },
   "Necrozma": {
     "t1": "Psychic",
@@ -12149,7 +12921,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 89,
       "sp": 79
     },
-    "w": 230.0,
+      "w": 230.0,
+      "ab": "Prism Armor",
   },
   "Magearna": {
     "t1": "Steel",
@@ -12162,7 +12935,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 115,
       "sp": 65
     },
-    "w": 80.5,
+      "w": 80.5,
+      "ab": "Soul-Heart",
   },
   "Marshadow": {
     "t1": "Fighting",
@@ -12175,7 +12949,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 90,
       "sp": 125
     },
-    "w": 22.2,
+      "w": 22.2,
+      "ab": "Technician",
   },
   "Poiple": {
     "t1": "Poison",
@@ -12187,7 +12962,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 67,
       "sp": 73
     },
-    "w": 1.8,
+      "w": 1.8,
+      "canEvolve": true,
   },
   "Naganadel": {
     "t1": "Poison",
@@ -12200,7 +12976,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 73,
       "sp": 121
     },
-    "w": 150.0,
+      "w": 150.0,
+      "ab": "Beast Boost",
   },
   "Blacephalon": {
     "t1": "Fire",
@@ -12213,7 +12990,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 79,
       "sp": 107
     },
-    "w": 13.0,
+      "w": 13.0,
+      "ab": "Beast Boost",
   },
   "Stakataka": {
     "t1": "Rock",
@@ -12226,7 +13004,8 @@ var POKEDEX_SM = $.extend(true, {}, POKEDEX_XY, {
       "sd": 101,
       "sp": 13
     },
-    "w": 820.0,
+      "w": 820.0,
+      "ab": "Beast Boost",
   },
   "Lycanroc-Dusk": {
     "t1": "Rock",
@@ -12357,7 +13136,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 40
     },
     "w": 7.5,
-    "ab": "Tough Claws",
+      "ab": "Tough Claws",
+      "canEvolve": true,
   },
   "Ponyta-Galar": {
     "t1": "Psychic",
@@ -12369,7 +13149,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 65,
       "sp": 90
     },
-    "w": 24,
+      "w": 24,
+      "canEvolve": true,
   },
   "Rapidash-Galar": {
     "t1": "Psychic",
@@ -12382,7 +13163,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 80,
       "sp": 105
     },
-    "w": 80,
+      "w": 80,
+      "ab": "Pastel Veil",
   },
   "Farfetch'd-Galar": {
     "t1": "Fighting",
@@ -12395,7 +13177,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 55
     },
     "w": 15,
-    "ab": "Scrappy",
+      "ab": "Scrappy",
+      "canEvolve": true,
   },
   "Weezing-Galar": {
     "t1": "Poison",
@@ -12422,7 +13205,9 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 90,
       "sp": 100
     },
-    "w": 56.8,
+      "w": 56.8,
+      "ab": "Screen Cleaner",
+      "canEvolve": true,
   },
   "Corsola-Galar": {
     "t1": "Ghost",
@@ -12434,7 +13219,9 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 100,
       "sp": 30
     },
-    "w": 0.5,
+      "w": 0.5,
+      "ab": "Cursed Body",
+      "canEvolve": true,
   },
   "Zigzagoon-Galar": {
     "t1": "Dark",
@@ -12447,7 +13234,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 41,
       "sp": 60
     },
-    "w": 17.5,
+      "w": 17.5,
+      "canEvolve": true,
   },
   "Linoone-Galar": {
     "t1": "Dark",
@@ -12460,7 +13248,9 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 61,
       "sp": 100
     },
-    "w": 32.5,
+      "w": 32.5,
+      "ab": "Quick Feet",
+      "canEvolve": true,
   },
   "Darumaka-Galar": {
     "t1": "Ice",
@@ -12472,7 +13262,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 45,
       "sp": 50
     },
-    "w": 40,
+      "w": 40,
+      "canEvolve": true,
   },
   "Darmanitan-Galar": {
     "t1": "Ice",
@@ -12488,10 +13279,10 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "ab": "Gorilla Tactics",
     "formes": [
       "Darmanitan-Galar",
-      "Darmanitan-Z-Galar"
+      "Darmanitan-Galar-Zen"
     ]
   },
-  "Darmanitan-Z-Galar": {
+  "Darmanitan-Galar-Zen": {
     "t1": "Ice",
     "t2": "Fire",
     "bs": {
@@ -12517,7 +13308,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 65,
       "sp": 30
     },
-    "w": 1.5,
+      "w": 1.5,
+      "canEvolve": true,
   },
   "Stunfisk-Galar": {
     "t1": "Ground",
@@ -12530,7 +13322,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 84,
       "sp": 32
     },
-    "w": 20.5,
+      "w": 20.5,
+      "ab": "Mimicry",
   },
   "Grookey": {
     "t1": "Grass",
@@ -12543,7 +13336,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 65
     },
     "w": 5,
-    "ab": "Overgrow",
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Thwackey": {
     "t1": "Grass",
@@ -12556,7 +13350,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 80
     },
     "w": 14,
-    "ab": "Overgrow",
+      "ab": "Overgrow",
+      "canEvolve": true,
   },
   "Rillaboom": {
     "t1": "Grass",
@@ -12586,7 +13381,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 69
     },
     "w": 4.5,
-    "ab": "Blaze",
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Raboot": {
     "t1": "Fire",
@@ -12599,7 +13395,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 94
     },
     "w": 9,
-    "ab": "Blaze",
+      "ab": "Blaze",
+      "canEvolve": true,
   },
   "Cinderace": {
     "t1": "Fire",
@@ -12629,7 +13426,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 70
     },
     "w": 4,
-    "ab": "Torrent",
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Drizzile": {
     "t1": "Water",
@@ -12642,7 +13440,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 90
     },
     "w": 11.5,
-    "ab": "Torrent",
+      "ab": "Torrent",
+      "canEvolve": true,
   },
   "Inteleon": {
     "t1": "Water",
@@ -12671,7 +13470,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 45,
       "sp": 45
     },
-    "w": 8,
+      "w": 8,
+      "canEvolve": true,
   },
   "Dottler": {
     "t1": "Bug",
@@ -12684,7 +13484,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 90,
       "sp": 30
     },
-    "w": 19.5,
+      "w": 19.5,
+      "canEvolve": true,
   },
   "Orbeetle": {
     "t1": "Bug",
@@ -12697,7 +13498,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 120,
       "sp": 90
     },
-    "w": 40.8,
+      "w": 40.8,
+      "ab": "Frisk",
   },
   "Rookidee": {
     "t1": "Flying",
@@ -12709,7 +13511,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 35,
       "sp": 57
     },
-    "w": 1.8,
+      "w": 1.8,
+      "canEvolve": true,
   },
   "Corvisquire": {
     "t1": "Flying",
@@ -12721,7 +13524,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 55,
       "sp": 77
     },
-    "w": 16,
+      "w": 16,
+      "canEvolve": true,
   },
   "Corviknight": {
     "t1": "Flying",
@@ -12766,7 +13570,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 35,
       "sp": 25
     },
-    "w": 2.5,
+      "w": 2.5,
+      "canEvolve": true,
   },
   "Greedent": {
     "t1": "Normal",
@@ -12778,7 +13583,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 75,
       "sp": 20
     },
-    "w": 6,
+      "w": 6,
+      "ab": "Cheek Pouch",
   },
   "Nickit": {
     "t1": "Dark",
@@ -12790,7 +13596,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 52,
       "sp": 50
     },
-    "w": 8.9,
+      "w": 8.9,
+      "canEvolve": true,
   },
   "Thievul": {
     "t1": "Dark",
@@ -12802,7 +13609,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 92,
       "sp": 90
     },
-    "w": 19.9,
+      "w": 19.9,
+      "ab": "Unburden",
   },
   "Gossifleur": {
     "t1": "Grass",
@@ -12814,7 +13622,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 60,
       "sp": 10
     },
-    "w": 2.2,
+      "w": 2.2,
+      "canEvolve": true,
   },
   "Eldegoss": {
     "t1": "Grass",
@@ -12826,7 +13635,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 120,
       "sp": 60
     },
-    "w": 2.5,
+      "w": 2.5,
+      "ab": "Cotton Down",
   },
   "Wooloo": {
     "t1": "Normal",
@@ -12839,7 +13649,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 48
     },
     "w": 6,
-    "ab": "Fluffy",
+      "ab": "Fluffy",
+      "canEvolve": true,
   },
   "Dubwool": {
     "t1": "Normal",
@@ -12865,7 +13676,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 44
     },
     "w": 8.5,
-    "ab": "Strong Jaw",
+      "ab": "Strong Jaw",
+      "canEvolve": true,
   },
   "Drednaw": {
     "t1": "Water",
@@ -12907,7 +13719,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 50,
       "sp": 26
     },
-    "w": 13.5,
+      "w": 13.5,
+      "canEvolve": true,
   },
   "Boltund": {
     "t1": "Electric",
@@ -12919,7 +13732,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 60,
       "sp": 121
     },
-    "w": 34,
+      "w": 34,
+      "ab": "Strong Jaw",
   },
   "Rolycoly": {
     "t1": "Rock",
@@ -12931,7 +13745,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 50,
       "sp": 30
     },
-    "w": 12,
+      "w": 12,
+      "canEvolve": true,
   },
   "Carkol": {
     "t1": "Rock",
@@ -12944,7 +13759,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 70,
       "sp": 50
     },
-    "w": 78,
+      "w": 78,
+      "canEvolve": true,
   },
   "Coalossal": {
     "t1": "Rock",
@@ -12987,7 +13803,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 40,
       "sp": 20
     },
-    "w": 0.5,
+      "w": 0.5,
+      "canEvolve": true,
   },
   "Flapple": {
     "t1": "Grass",
@@ -13066,7 +13883,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 46
     },
     "w": 7.6,
-    "ab": "Sand Spit",
+      "ab": "Sand Spit",
+      "canEvolve": true,
   },
   "Sandaconda": {
     "t1": "Ground",
@@ -13110,7 +13928,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 95,
       "sp": 85
     },
-    "w": 18,
+      "w": 18,
+      "ab": "Gulp Missile",
   },
   "Arrokuda": {
     "t1": "Water",
@@ -13122,7 +13941,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 30,
       "sp": 66
     },
-    "w": 1,
+      "w": 1,
+      "canEvolve": true,
   },
   "Barraskewda": {
     "t1": "Water",
@@ -13134,7 +13954,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 50,
       "sp": 136
     },
-    "w": 30,
+      "w": 30,
+      "ab": "Swift Swim",
   },
   "Toxel": {
     "t1": "Electric",
@@ -13147,7 +13968,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 35,
       "sp": 40
     },
-    "w": 11,
+      "w": 11,
+      "canEvolve": true,
   },
   "Toxtricity": {
     "t1": "Electric",
@@ -13194,7 +14016,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 45
     },
     "w": 1,
-    "ab": "White Smoke",
+      "ab": "White Smoke",
+      "canEvolve": true,
   },
   "Centiskorch": {
     "t1": "Fire",
@@ -13240,7 +14063,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 32
     },
     "w": 4,
-    "ab": "Technician",
+      "ab": "Technician",
+      "canEvolve": true,
   },
   "Grapploct": {
     "t1": "Fighting",
@@ -13265,7 +14089,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 54,
       "sp": 50
     },
-    "w": 0.2,
+      "w": 0.2,
+      "canEvolve": true,
   },
   "Polteageist": {
     "t1": "Ghost",
@@ -13277,7 +14102,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 114,
       "sp": 70
     },
-    "w": 0.4,
+      "w": 0.4,
+      "ab": "Cursed Body",
   },
   "Hatenna": {
     "t1": "Psychic",
@@ -13289,7 +14115,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 53,
       "sp": 39
     },
-    "w": 3.4,
+      "w": 3.4,
+      "canEvolve": true,
   },
   "Hattrem": {
     "t1": "Psychic",
@@ -13301,7 +14128,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 73,
       "sp": 49
     },
-    "w": 4.8,
+      "w": 4.8,
+      "canEvolve": true,
   },
   "Hatterene": {
     "t1": "Psychic",
@@ -13347,7 +14175,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 40,
       "sp": 50
     },
-    "w": 5.5,
+      "w": 5.5,
+      "canEvolve": true,
   },
   "Morgrem": {
     "t1": "Dark",
@@ -13360,7 +14189,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 55,
       "sp": 70
     },
-    "w": 12.5,
+      "w": 12.5,
+      "canEvolve": true,
   },
   "Grimmsnarl": {
     "t1": "Dark",
@@ -13432,7 +14262,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 130,
       "sp": 30
     },
-    "w": 0.4,
+      "w": 0.4,
+      "ab": "Perish Body",
   },
   "Sirfetch'd": {
     "t1": "Fighting",
@@ -13458,7 +14289,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 100,
       "sp": 70
     },
-    "w": 58.2,
+      "w": 58.2,
+      "ab": "Screen Cleaner",
   },
   "Runerigus": {
     "t1": "Ground",
@@ -13471,7 +14303,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 105,
       "sp": 30
     },
-    "w": 66.6,
+      "w": 66.6,
+      "ab": "Wandering Spirit",
   },
   "Milcery": {
     "t1": "Fairy",
@@ -13483,7 +14316,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 61,
       "sp": 34
     },
-    "w": 0.3,
+      "w": 0.3,
+      "canEvolve": true,
   },
   "Alcremie": {
     "t1": "Fairy",
@@ -13554,7 +14388,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 20
     },
     "w": 3.8,
-    "ab": "Ice Scales",
+      "ab": "Ice Scales",
+      "canEvolve": true,
   },
   "Frosmoth": {
     "t1": "Ice",
@@ -13580,7 +14415,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 20,
       "sp": 70
     },
-    "w": 520,
+      "w": 520,
+      "ab": "Power Spot",
   },
   "Eiscue": {
     "t1": "Ice",
@@ -13592,7 +14428,12 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 90,
       "sp": 50
     },
-    "w": 89,
+      "w": 89,
+      "ab": "Ice Face",
+      "formes": [
+          "Eiscue",
+          "Eiscue-Noice"
+      ],
   },
   "Eiscue-Noice": {
     "t1": "Ice",
@@ -13604,7 +14445,9 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sd": 50,
       "sp": 130
     },
-    "w": 89,
+      "w": 89,
+      "ab": "Ice Face",
+      "isAlternateForme": true,
   },
   "Indeedee-M": {
     "t1": "Psychic",
@@ -13649,7 +14492,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
     "formes": [
       "Morpeko",
       "Morpeko-Hangry"
-    ]
+      ],
+      "ab": "Hunger Switch",
   },
   "Morpeko-Hangry": {
     "t1": "Electric",
@@ -13663,7 +14507,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 97
     },
     "w": 3,
-    "isAlternateForme": true
+      "isAlternateForme": true,
+      "ab": "Hunger Switch",
   },
   "Cufant": {
     "t1": "Steel",
@@ -13676,7 +14521,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 40
     },
     "w": 100,
-    "ab": "Sheer Force",
+      "ab": "Sheer Force",
+      "canEvolve": true,
   },
   "Copperajah": {
     "t1": "Steel",
@@ -13735,7 +14581,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 55
     },
     "w": 150,
-    "ab": "Volt Absorb",
+    "ab": "Slush Rush",
   },
   "Dracovish": {
     "t1": "Water",
@@ -13763,7 +14609,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 55
     },
     "w": 215,
-    "ab": "Water Absorb",
+    "ab": "Slush Rush",
   },
   "Duraludon": {
     "t1": "Steel",
@@ -13810,7 +14656,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 82
     },
     "w": 2,
-    "ab": "Clear Body",
+      "ab": "Clear Body",
+      "canEvolve": true,
   },
   "Drakloak": {
     "t1": "Dragon",
@@ -13824,7 +14671,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       "sp": 102
     },
     "w": 11,
-    "ab": "Clear Body",
+      "ab": "Clear Body",
+      "canEvolve": true,
   },
   "Dragapult": {
     "t1": "Dragon",
@@ -13929,6 +14777,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
       },
       "w": 12,
       "ab": "Inner Focus",
+      "canEvolve": true,
   },
   "Urshifu-Single Strike": {
       "t1": "Fighting",
@@ -14008,6 +14857,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sp": 105
       },
       "w": 70,
+      "ab": "Leaf Guard",
   },
   "Rillaboom-Gmax": {
       "t1": "Grass",
@@ -14061,7 +14911,9 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
         "sd": 40,
         "sp": 15
     },
-    "w": 36.0
+      "w": 36.0,
+      "ab": "Regenerator",
+      "canEvolve": true,
   },
   "Slowbro-Galar":{
       "t1": "Poison",
@@ -14074,7 +14926,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sd": 70,
           "sp": 30
       },
-      "w": 70.5
+      "w": 70.5,
+      "ab": "Quick Draw",
   },
   "Slowking-Galar": {
       "t1": "Poison",
@@ -14087,7 +14940,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sd": 110,
           "sp": 30
       },
-      "w": 79.5
+      "w": 79.5,
+      "ab": "Curious Medicine",
   },
   "Articuno-Galar": {
       "t1": "Psychic",
@@ -14128,7 +14982,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sd": 125,
           "sp": 90
       },
-      "w": 66.0
+      "w": 66.0,
+      "ab": "Berserk",
   },
   "Regieleki": {
       "t1": "Electric",
@@ -14166,7 +15021,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sd": 110,
           "sp": 30
       },
-      "w": 800.0
+      "w": 800.0,
+      "ab": "Chilling Neigh",
   },
   "Spectrier": {
       "t1": "Ghost",
@@ -14178,7 +15034,8 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
           "sd": 80,
           "sp": 130
       },
-      "w": 44.5
+      "w": 44.5,
+      "ab": "Grim Neigh",
   },
   "Calyrex": {
       "t1": "Psychic",
@@ -14292,7 +15149,7 @@ var POKEDEX_SS_NATDEX = $.extend(true, {}, POKEDEX_SM, {
             "sp": 70,
         },
         "w": 32.0,
-        "ab": "Compoundeyes",
+        "ab": "Compound Eyes",
         "isAlternateForme": true,
     },
     "Pikachu-Gmax": {
@@ -14576,6 +15433,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 22.7,
         "ab": "Intimidate",
+        "canEvolve": true,
     },
     "Arcanine-Hisui": {
         "t1": "Fire",
@@ -14604,6 +15462,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 13.0,
         "ab": "Soundproof",
+        "canEvolve": true,
     },
     "Electrode-Hisui": {
         "t1": "Electric",
@@ -14646,6 +15505,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 3.9,
         "ab": "Swift Swim",
+        "canEvolve": true,
     },
     "Sneasel-Hisui": {
         "t1": "Fighting",
@@ -14660,6 +15520,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 27.0,
         "ab": "Inner Focus",
+        "canEvolve": true,
     },
     "Samurott-Hisui": {
         "t1": "Water",
@@ -14702,6 +15563,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 12.5,
         "ab": "Illusion",
+        "canEvolve": true,
     },
     "Zoroark-Hisui": {
         "t1": "Normal",
@@ -14744,6 +15606,7 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         },
         "w": 68.5,
         "ab": "Overcoat",
+        "canEvolve": true,
     },
     "Goodra-Hisui": {
         "t1": "Steel",
@@ -14941,4 +15804,11 @@ var POKEDEX_LA = $.extend(true, {}, POKEDEX_SS_NATDEX, {
         "w": 660.0,
         "ab": "Pressure",
     },
+
+    //EVIOLITE ELIGIBILITY CHANGES
+    "Stantler": { "canEvolve": true, },
+    "Ursaring": { "canEvolve": true, },
+    "Basculin": { "canEvolve": true, },
 });
+
+var POKEDEX_SV_NATDEX = $.extend(true, {}, POKEDEX_LA, {});

--- a/script_res/setdex_custom.js
+++ b/script_res/setdex_custom.js
@@ -102,6 +102,10 @@ if (readCookie("custom_gen_84") != null) {
     SETDEX_CUSTOM_BDSP = JSON.parse(readCookie("custom_gen_84"));
     reloadBDSPScript();
 }
+if (readCookie("custom_gen_9") != null) {
+    SETDEX_CUSTOM_SV = JSON.parse(readCookie("custom_gen_9"));
+    reloadSVScript();
+}
 
 var deletecustom = function () {
     gen = parseInt($('input[name="gen"]:checked').val());
@@ -130,6 +134,11 @@ var deletecustom = function () {
             SETDEX_CUSTOM_BDSP = {};
             eraseCookie("custom_gen_" + gen);
             reloadBDSPScript();
+            break;
+        case 9:
+            SETDEX_CUSTOM_SV = {};
+            eraseCookie("custom_gen_" + gen);
+            reloadSVScript();
             break;
         default:
             console.log("THIS SHOULDN\'T HAPPEN LOL");
@@ -170,6 +179,9 @@ var savecustom = function()
 	var spreadName = document.getElementById('spreadName').value
 	if(spreadName == '')
         spreadName = "My Custom Set";
+    //if ('https://pokepast.es/'.indexOf(string) !== -1) {
+    //    $.ajax({ url: 'string', success: function (data) { alert(data); } });
+    //}
 
     //numPokemon separates individual Pokemon so user can add multiple Pokemon at once under the same set name
     var numPokemon = string.split('\n\n')
@@ -375,6 +387,12 @@ var savecustom = function()
                 SETDEX_CUSTOM_BDSP[species][spreadName] = customFormat
                 createCookie("custom_gen_84", JSON.stringify(SETDEX_CUSTOM_BDSP), 365)
                 break;
+            case 9:
+                if (SETDEX_CUSTOM_SV[species] == null)
+                    SETDEX_CUSTOM_SV[species] = {}
+                SETDEX_CUSTOM_SV[species][spreadName] = customFormat
+                createCookie("custom_gen_8", JSON.stringify(SETDEX_CUSTOM_SV), 365)
+                break;
             default:
                 console.log("THIS SHOULDN\'T HAPPEN LOL");
         }
@@ -492,6 +510,13 @@ var savecalc = function (set, spreadName, accessIVs) {
             SETDEX_CUSTOM_BDSP[species][spreadName] = customFormat
                 createCookie("custom_gen_84", JSON.stringify(SETDEX_CUSTOM_BDSP), 365)
             reloadBDSPScript()
+            break;
+        case 9:
+            if (SETDEX_CUSTOM_SV[species] == null)
+                SETDEX_CUSTOM_SV[species] = {}
+            SETDEX_CUSTOM_SV[species][spreadName] = customFormat
+            createCookie("custom_gen_8", JSON.stringify(SETDEX_CUSTOM_SV), 365)
+            reloadSVScript()
             break;
         default:
             console.log("THIS SHOULDN\'T HAPPEN LOL");

--- a/script_res/setdex_ncp-g8.js
+++ b/script_res/setdex_ncp-g8.js
@@ -476,6 +476,29 @@ var SETDEX_VGC2021 = {
                 "Flamethrower",
                 "Psyshock"
             ]
+        },
+        "2022 Body Press Set": {
+            "level": 50,
+            "evs": {
+                "hp": 244,
+                "at": 0,
+                "df": 12,
+                "sa": 0,
+                "sd": 252,
+                "sp": 0
+            },
+            "ivs": {
+                "at": 0,
+            },
+            "nature": "Calm",
+            "ability": "Oblivious",
+            "item": "Wacan Berry",
+            "moves": [
+                "Iron Defense",
+                "Body Press",
+                "Protect",
+                "Trick Room"
+            ]
         }
     },
     "Omastar": {
@@ -10417,6 +10440,29 @@ var SETDEX_VGC2022 = {
                 "Ally Switch",
                 "Endure",
                 "Poltergeist"
+            ]
+        },
+
+    },
+    "Yveltal": {
+        "Hamstermania's Worlds Top 16 Serious Yveltal": {
+            "level": 50,
+            "evs": {
+                "hp": 252,
+                "at": 4,
+                "df": 76,
+                "sa": 68,
+                "sd": 60,
+                "sp": 44
+            },
+            "nature": "Serious",
+            "ability": "Dark Aura",
+            "item": "Assault Vest",
+            "moves": [
+                "Foul Play",
+                "Sucker Punch",
+                "Oblivion Wing",
+                "Snarl"
             ]
         },
 


### PR DESCRIPTION
To summarize as best as possible:
- The function that handles damage has been divided into lots of smaller functions (see damage_MASTER.js)
- A couple of parts of the calculations have been adjusted to be accurate
- Triple Axel now calculates each individual hit correctly and the only reason why I'm mentioning this is because it looks like this is a first for ANY damage calculator which is neat
- The Pledge moves also are being handled differently with a menu to choose which other Pledge move to combine it with
- There is also LOTS of comments in damage_MASTER.js to make sure it's clear how everything is supposed to work
- Somehow missed Mental Herb so that's been added
- Increase efficiency in looking up Mega Stones and Signature Z-moves
- Every Status move has been given a type (it looks better and plays nicer with the calculator)
- Gave most evolved Pokemon a default ability and gave all pre-evolutions an indicator for Eviolite
- Changed button placement to make the calculator look nicer
- The following abilities now have functionality in the calculator: Damp, Minus, Plus, Trace, Quick Feet, Unburden, Stakeout, and Mimicry
- The following abilities have changed functionality: Flash Fire, Intimidate, and Slow Start
- Certain abilities now have an option to activate them or not, those being: Flash Fire, Plus, Minus, Trace, Stakeout, Intimidate, and Slow Start
- Some basic WIPs for SV but it's still too early to implement