### PR TITLE
Champions: fix audited data divergences, Protect handling, and five damage-formula bugs

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,6 +255,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL1" /><label class="double-btn btn x-btn" for="doubleL1" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL1" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL1" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -269,6 +270,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL2" /><label class="double-btn btn x-btn" for="doubleL2" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL2" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL2" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -283,6 +285,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL3" /><label class="double-btn btn x-btn" for="doubleL3" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL3" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL3" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -297,6 +300,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL4" /><label class="double-btn btn x-btn" for="doubleL4" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL4" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL4" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -777,6 +781,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR1" /><label class="double-btn btn x-btn" for="doubleR1" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR1" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR1" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -791,6 +796,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR2" /><label class="double-btn btn x-btn" for="doubleR2" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR2" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR2" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -805,6 +811,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR3" /><label class="double-btn btn x-btn" for="doubleR3" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR3" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR3" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -819,6 +826,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR4" /><label class="double-btn btn x-btn" for="doubleR4" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR4" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR4" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>

--- a/script_res/ability_data.js
+++ b/script_res/ability_data.js
@@ -396,7 +396,7 @@ var ABILITIES_CHAMPIONS = [
     'Volt Absorb', 'Wandering Spirit', 'Water Absorb',
     'Water Bubble', 'Weak Armor', 'White Smoke', 'Zero to Hero',
     //Regulation M-B additions
-    'Eelevate', 'Effect Spore', 'Electric Surge', 'Fire Mane', 'Fluffy', 'Forewarn', 'Good as Gold', 'Huge Power',
+    'Eelevate', 'Effect Spore', 'Electric Surge', 'Fire Mane', 'Fluffy', 'Forewarn', 'Good as Gold',
     //Regulation M-C additions
     'Run Away', 'Liquid Ooze', 'Rattled', 'Grass Pelt', 'Emergency Exit', 'Stakeout', 'Psychic Surge', 'Grassy Surge',
     'Libero', 'Punk Rock', 'Steely Spirit', 'Seed Sower', 'Thermal Exchange', 'Guard Dog', 'Aura Guard',

--- a/script_res/ap_calc.js
+++ b/script_res/ap_calc.js
@@ -779,6 +779,12 @@ $(".move-selector").change(function() {
     }
     else moveGroupObj.children(".move-linearAddedBP").hide();
 
+    if (move.stockpileBP) {
+        moveGroupObj.children(".move-stockpiles").show();
+        moveGroupObj.children(".move-stockpiles").val(0);
+    }
+    else moveGroupObj.children(".move-stockpiles").hide();
+
     if (move.usesOppMoves) {    //for when the attacker's moves change
         getOppMoves($(this).closest(".poke-info").attr("id"), moveGroupObj);
         moveGroupObj.children(".move-opponent").show();
@@ -2083,6 +2089,7 @@ function getMoveDetails(moveInfo, maxMon) {
         isDouble: (defaultDetails.canDouble && !moveInfo.find(".move-z").prop("checked") && !maxMon && moveInfo.find(".move-double").prop("checked")) ? 1 : 0,
         combinePledge: (defaultDetails.isPledge && !moveInfo.find(".move-z").prop("checked") && !maxMon) ? moveInfo.find(".move-pledge").val() : 0,
         timesAffected: (defaultDetails.linearAddBP && !moveInfo.find(".move-z").prop("checked") && !maxMon) ? ~~moveInfo.find(".move-linearAddedBP").val() : 0,
+        stockpiles: (defaultDetails.stockpileBP && !moveInfo.find(".move-z").prop("checked") && !maxMon) ? ~~moveInfo.find(".move-stockpiles").val() : 0,
         usedOppMoveIndex: moveInfo.find(".move-opponent").prop("selectedIndex"),
         getsStellarBoost: moveInfo.find(".move-stellar").prop("checked"),
         isPlusMove: moveInfo.find(".move-plus").prop("checked"),

--- a/script_res/damage_MASTER.js
+++ b/script_res/damage_MASTER.js
@@ -733,11 +733,13 @@ function checkMoveTypeChange(move, field, attacker) {
                         : "Normal";
     }
     else if (move.name == "Terrain Pulse") {
-        move.type = field.terrain === "Electric" ? "Electric"
-            : field.terrain === "Grassy" ? "Grass"
-                : field.terrain === "Misty" ? "Fairy"
-                    : field.terrain === "Psychic" ? "Psychic"
-                        : "Normal";
+        //The type only follows the terrain while the USER is grounded, matching the x2 BP gate in basePowerFunc
+        move.type = !pIsGrounded(attacker, field) ? "Normal"
+            : field.terrain === "Electric" ? "Electric"
+                : field.terrain === "Grassy" ? "Grass"
+                    : field.terrain === "Misty" ? "Fairy"
+                        : field.terrain === "Psychic" ? "Psychic"
+                            : "Normal";
     }
     else if (move.name == "Techno Blast") {
         move.type = attacker.item === "Burn Drive" ? "Fire"
@@ -988,7 +990,8 @@ function checkMeFirst(move, moveDescName, defender, isDynamax) {
 
 function statusMoves(move, attacker, defender, description) {
     if (move.name === "Pain Split" && attacker.item !== "Assault Vest") {
-        return { "damage": [Math.floor((defender.curHP - attacker.curHP) / 2)], "description": buildDescription(description) };
+        var painSplitHP = Math.floor((attacker.curHP + defender.curHP) / 2);
+        return { "damage": [Math.max(0, defender.curHP - painSplitHP)], "description": buildDescription(description) };
     }
     else if (move.bp === 0 || move.category === "Status") {
         return { "damage": [0], "description": buildDescription(description) };
@@ -1173,6 +1176,9 @@ function setDamage(move, attacker, defender, description, isQuarteredByProtect, 
     if (move.name === "Spit Up" && !move.stockpiles) {
         return { "damage": [0], "description": buildDescription(description) };
     }
+    if (move.name === "Steel Roller" && !(field && field.terrain)) {
+        return { "damage": [0], "description": buildDescription(description) };
+    }
     //a. Counterattacks (Counter, Mirror Coat, Metal Burst, Comeuppance, Bide)
     if (['Counter', 'Mirror Coat', 'Metal Burst', 'Comeuppance'].indexOf(move.name) !== -1) {
         var counteredMove = defender.moves[move.usedOppMoveIndex];
@@ -1308,7 +1314,7 @@ function basePowerFunc(move, description, turnOrder, attacker, defender, field, 
         //a. Speed based
         //a.i. Gyro Ball
         case "Gyro Ball":
-            basePower = Math.min(150, Math.floor(25 * defender.stats[SP] / attacker.stats[SP]));
+            basePower = Math.min(150, Math.floor(25 * defender.stats[SP] / attacker.stats[SP]) + 1);
             description.moveBP = basePower;
             break;
         //a.ii. Electro Ball
@@ -1961,7 +1967,7 @@ function calcAtMods(move, attacker, defAbility, description, field) {
         || (attacker.ability === "Flash Fire" && attacker.abilityOn && move.type === "Fire")
         || (attacker.ability === "Steelworker" && move.type === "Steel")
         || (attacker.ability === "Gorilla Tactics" && move.category === "Physical" && !attacker.isDynamax)
-        || (["Plus", "Minus"].indexOf(attacker.ability) !== -1 && attacker.abilityOn)
+        || (["Plus", "Minus"].indexOf(attacker.ability) !== -1 && attacker.abilityOn && move.category === "Special")
         || (attacker.ability === "Sharpness" && move.isSlice)
         || (attacker.ability === "Rocky Payload" && move.type === "Rock")
         || (attacker.ability === "Fire Mane" && move.type === "Fire")) {

--- a/script_res/damage_MASTER.js
+++ b/script_res/damage_MASTER.js
@@ -830,7 +830,7 @@ function checkContactOverride(move, attacker) {
 }
 
 function setIsQuarteredByProtect(attacker, defender, field, move, description) {
-    let qualifiedQuartered = field.isProtect && (move.isZ || move.isSignatureZ || attacker.isDynamax || attacker.ability === 'Piercing Drill' || (attacker.ability === 'Unseen Fist' && gen >= 10));
+    let qualifiedQuartered = field.isProtect && (move.isZ || move.isSignatureZ || attacker.isDynamax || attacker.ability === 'Piercing Drill' || (attacker.ability === 'Unseen Fist' && gen >= 10 && move.makesContact));
     if (qualifiedQuartered && attacker.ability === 'Piercing Drill') description.attackerAbility = attacker.ability;
     return qualifiedQuartered;
 }
@@ -1170,6 +1170,9 @@ function immunityChecks(move, attacker, defender, field, description, defAbility
 //Special Cases
 function setDamage(move, attacker, defender, description, isQuarteredByProtect, field) {
     var isParentBond = attacker.ability === "Parental Bond";
+    if (move.name === "Spit Up" && !move.stockpiles) {
+        return { "damage": [0], "description": buildDescription(description) };
+    }
     //a. Counterattacks (Counter, Mirror Coat, Metal Burst, Comeuppance, Bide)
     if (['Counter', 'Mirror Coat', 'Metal Burst', 'Comeuppance'].indexOf(move.name) !== -1) {
         var counteredMove = defender.moves[move.usedOppMoveIndex];
@@ -1380,6 +1383,10 @@ function basePowerFunc(move, description, turnOrder, attacker, defender, field, 
         //e.i. Fury Cutter
         //e.ii. Rollout, Ice Ball
         //e.iii. Spit Up
+        case "Spit Up":
+            basePower = 100 * move.stockpiles;
+            description.moveBP = basePower;
+            break;
 
         //f. Boost based
         //f.i. Stored Power, Power Trip

--- a/script_res/move_data.js
+++ b/script_res/move_data.js
@@ -1973,11 +1973,12 @@ var MOVES_ADV = $.extend(true, {}, MOVES_GSC, {
         category: 'Special',
         isSound: true,
     },
-    //'Spit Up': {
-    //    bp: 1,
-    //    type: 'Normal',
-    //    category: 'Special',
-    //},
+    'Spit Up': {
+        bp: 1,
+        type: 'Normal',
+        category: 'Special',
+        stockpileBP: true,
+    },
     'Smelling Salts': {
         bp: 60,
         type: 'Normal',
@@ -4894,6 +4895,7 @@ var MOVES_SS = $.extend(true, {}, MOVES_SM, {
         bp: 80,
         type: 'Psychic',
         category: 'Special',
+        isSound: true,
         hasSecondaryEffect: true,
     },
     'Fiery Wrath': {
@@ -5721,6 +5723,7 @@ var MOVES_ZA_NATDEX = $.extend(true, {}, MOVES_SV_NATDEX, {
 });
 
 var MOVES_CHAMPIONS_NATDEX = $.extend(true, {}, MOVES_ZA_NATDEX, {
+    'Pound': { bp: 40 },
     'Growth': { type: 'Grass' },
     'Bone Rush': { bp: 30 },
     'Night Daze': { bp: 90 },
@@ -5755,7 +5758,6 @@ var MOVES_CHAMPIONS_NATDEX = $.extend(true, {}, MOVES_ZA_NATDEX, {
     'Anchor Shot': { bp: 90 },
     'Revelation Dance': { bp: 100 },
     'Dragon Hammer': { bp: 100 },
-    'Snipe Shot': { bp: 85 },
     'Bolt Beak': { bp: 80 },
     'Fishious Rend': { bp: 80 },
     'Astral Barrage': { bp: 110 },
@@ -5816,7 +5818,7 @@ var MOVES_CHAMPIONS = {};
     'Shed Tail', 'Sheer Cold', 'Shell Side Arm', 'Shell Smash', 'Shelter', 'Simple Beam', 'Sing', 'Skill Swap',
     'Skitter Smack', 'Sky Attack', 'Slack Off', 'Sleep Powder', 'Sleep Talk', 'Sludge Bomb', 'Sludge Wave', 'Smack Down',
     'Smart Strike', 'Snap Trap', 'Snarl', 'Snore', 'Snowscape', 'Soak', 'Solar Beam',
-    'Solar Blade', 'Sparkling Aria', 'Speed Swap', 'Spicy Extract', 'Spikes', 'Spiky Shield', 'Spirit Shackle', /*'Spit Up',*/
+    'Solar Blade', 'Sparkling Aria', 'Speed Swap', 'Spicy Extract', 'Spikes', 'Spiky Shield', 'Spirit Shackle', 'Spit Up',
     'Spite', 'Stealth Rock', 'Steel Beam', 'Steel Roller', 'Steel Wing', 'Sticky Web', 'Stockpile',
     'Stomping Tantrum', 'Stone Axe', 'Stone Edge', 'Stored Power', 'Storm Throw', 'Strength Sap', 'String Shot', 'Struggle', 'Struggle Bug',
     'Stuff Cheeks', 'Stun Spore', 'Substitute', 'Sucker Punch', 'Sunny Day', 'Super Fang', 'Supercell Slam', 'Superpower',
@@ -5833,7 +5835,6 @@ var MOVES_CHAMPIONS = {};
     //Moves available starting Regulation M-B
     'Barb Barrage', 'Make It Rain', 'No Retreat', 'Rage Fist', 'Spirit Break', 'Topsy-Turvy',
     //Moves available starting Regulation M-C
-    'Slash', 'Octazooka', 'Milk Drink', 'Shift Gear', 'Zing Zap', 'Snipe Shot', 'Jaw Lock', 'Octolock', 'Court Change', 'Drum Beating', 'Pyro Ball',
-    'Meteor Assault', 'Glaive Rush', 'Revival Blessing', 'Double Shock',
+    'Slash', 'Milk Drink', 'Shift Gear', 'Zing Zap', 'Snipe Shot', 'Jaw Lock', 'Octolock', 'Court Change', 'Drum Beating', 'Pyro Ball',
+    'Meteor Assault', 'Glaive Rush', 'Revival Blessing', 'Double Shock', 'Overdrive', 'Pound',
 ].forEach(e => MOVES_CHAMPIONS[e] = MOVES_CHAMPIONS_NATDEX[e]);
-//Spit Up is commented out because it hasn't been implemented

--- a/script_res/pokedex.js
+++ b/script_res/pokedex.js
@@ -17821,8 +17821,8 @@ var POKEDEX_ZA_NATDEX = $.extend(true, {}, POKEDEX_SV_NATDEX, {
         "isAlternateForme": true,
     },
     "Mega Chandelure": {
-        "t1": "Fire",
-        "t2": "Ghost",
+        "t1": "Ghost",
+        "t2": "Fire",
         "bs": {
             "hp": 60,
             "at": 75,
@@ -18431,7 +18431,7 @@ var POKEDEX_CHAMPIONS = {};
     'Mega Scrafty', 'Mega Eelektross', 'Mega Pyroar', 'Mega Malamar', 'Mega Barbaracle', 'Mega Dragalge', 'Mega Falinks',
     //Regulation M-C additions
     'Wigglytuff', 'Persian', "Farfetch'd", 'Mr. Mime', 'Swalot', 'Salamence', 'Gogoat', 'Golisopod', 'Rillaboom', 'Cinderace', 'Inteleon', 'Thievul', 'Toxtricity',
-    'Graploct', 'Perrserker', "Sirfetch'd", 'Pincurchin', 'Indeedee', 'Pawmot', 'Arboliva', 'Squawkabilly', 'Mabosstiff', 'Baxcalibur',
+    'Grapploct', 'Perrserker', "Sirfetch'd", 'Pincurchin', 'Indeedee', 'Pawmot', 'Arboliva', 'Squawkabilly', 'Mabosstiff', 'Baxcalibur',
     //Forms of Regulation M-C additions
     'Persian-Alola', 'Mega Absol Z', 'Mega Salamence', 'Mega Garchomp Z', 'Mega Lucario Z', 'Mega Golisopod', 'Indeedee-F', 'Mega Baxcalibur',
 ].forEach(e => POKEDEX_CHAMPIONS[e] = POKEDEX_ZA_NATDEX[e]);

--- a/tests/champions_pr_acceptance.js
+++ b/tests/champions_pr_acceptance.js
@@ -47,7 +47,7 @@ const context = vm.createContext({
     JSON,
     gen: 10,
     move: { makesContact: false },
-    $: { extend: deepExtend },
+    $: Object.assign(function () { return { val() { return undefined; }, is() { return false; }, prop() { return undefined; }, text() {}, find() { return this; } }; }, { extend: deepExtend }),
 });
 
 function load(relativePath) {
@@ -56,6 +56,7 @@ function load(relativePath) {
     return source;
 }
 
+load('script_res/stat_data.js');
 load('script_res/pokedex.js');
 const moveDataSource = load('script_res/move_data.js');
 load('script_res/ability_data.js');
@@ -175,5 +176,72 @@ for (const filename of ['index.html', 'za-calc.html']) {
     const html = fs.readFileSync(path.join(repo, filename), 'utf8');
     assert.equal((html.match(/class="move-stockpiles calc-trigger hide"/g) || []).length, 8);
 }
+
+
+// --- Champions damage-engine fixes -------------------------------------------------
+
+// Gyro Ball's BP is 25 * targetSpeed / userSpeed + 1, capped at 150.
+function gyroBallBP(userSpeed, targetSpeed) {
+    const [bp] = context.basePowerFunc(
+        { name: 'Gyro Ball', bp: 1 }, {}, '',
+        { stats: { sp: userSpeed } }, { stats: { sp: targetSpeed } }, {}, true, true, '',
+    );
+    return bp;
+}
+assert.equal(gyroBallBP(100, 200), 51);
+assert.equal(gyroBallBP(100, 100), 26);
+assert.equal(gyroBallBP(200, 100), 13);
+assert.equal(gyroBallBP(10, 1000), 150);
+
+// Plus and Minus raise Sp. Atk only, so a physical move gets no 1.5x.
+function plusMinusMods(ability, category) {
+    const attacker = {
+        ability, abilityOn: true, item: '', name: '', status: 'Healthy',
+        curHP: 100, maxHP: 100, boosts: {}, hasCustomModifiers: false,
+    };
+    const [mods] = context.calcAtMods(
+        { name: 'Probe', category, type: 'Normal' },
+        attacker, '', {},
+        { weather: '', terrain: '', isNeutralizingGas: false, isRedItem: false, isFlowerGiftAtk: false },
+    );
+    return Array.from(mods);
+}
+for (const ability of ['Plus', 'Minus']) {
+    assert.ok(plusMinusMods(ability, 'Special').includes(0x1800));
+    assert.equal(plusMinusMods(ability, 'Physical').includes(0x1800), false);
+}
+
+// Pain Split drops the target to the average HP and never reports negative damage.
+function painSplit(attackerHP, defenderHP) {
+    return context.statusMoves(
+        { name: 'Pain Split', bp: 0, category: 'Status' },
+        { item: '', curHP: attackerHP }, { curHP: defenderHP }, {},
+    ).damage[0];
+}
+assert.equal(painSplit(100, 160), 30);
+assert.equal(painSplit(100, 101), 1);
+assert.equal(painSplit(150, 100), 0);
+assert.equal(painSplit(100, 100), 0);
+
+// Terrain Pulse only takes the terrain's type while the user is grounded.
+function terrainPulseType(attacker) {
+    const move = { name: 'Terrain Pulse', type: 'Normal' };
+    context.checkMoveTypeChange(move, { terrain: 'Grassy', weather: '' }, {
+        item: '', ability: '', hasType() { return false; }, ...attacker,
+    });
+    return move.type;
+}
+assert.equal(terrainPulseType({}), 'Grass');
+assert.equal(terrainPulseType({ ability: 'Levitate' }), 'Normal');
+assert.equal(terrainPulseType({ item: 'Air Balloon' }), 'Normal');
+assert.equal(terrainPulseType({ hasType(type) { return type === 'Flying'; } }), 'Normal');
+
+// Steel Roller fails when no terrain is active.
+const steelRoller = { name: 'Steel Roller', bp: 130, category: 'Physical' };
+assert.deepEqual(
+    Array.from(context.setDamage(steelRoller, { ability: '' }, {}, {}, false, { terrain: '' }).damage),
+    [0],
+);
+assert.equal(context.setDamage(steelRoller, { ability: '' }, {}, {}, false, { terrain: 'Grassy' }), -1);
 
 process.stdout.write('Champions PR acceptance checks passed.\n');

--- a/tests/champions_pr_acceptance.js
+++ b/tests/champions_pr_acceptance.js
@@ -1,0 +1,179 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+const repo = path.resolve(__dirname, '..');
+
+function isPlainObject(value) {
+    return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function cloneValue(value) {
+    if (Array.isArray(value)) return value.map(cloneValue);
+    if (!isPlainObject(value)) return value;
+    const result = {};
+    for (const [key, child] of Object.entries(value)) result[key] = cloneValue(child);
+    return result;
+}
+
+function deepExtend(...args) {
+    let deep = false;
+    if (args[0] === true) {
+        deep = true;
+        args.shift();
+    }
+    const target = args.shift() || {};
+    for (const source of args) {
+        if (source == null) continue;
+        for (const [key, value] of Object.entries(source)) {
+            if (deep && isPlainObject(value)) {
+                target[key] = deepExtend(true, isPlainObject(target[key]) ? target[key] : {}, value);
+            }
+            else if (deep) {
+                target[key] = cloneValue(value);
+            }
+            else {
+                target[key] = value;
+            }
+        }
+    }
+    return target;
+}
+
+const context = vm.createContext({
+    console: { log() {}, warn() {}, error() {} },
+    Math,
+    JSON,
+    gen: 10,
+    move: { makesContact: false },
+    $: { extend: deepExtend },
+});
+
+function load(relativePath) {
+    const source = fs.readFileSync(path.join(repo, relativePath), 'utf8');
+    vm.runInContext(source, context, { filename: relativePath });
+    return source;
+}
+
+load('script_res/pokedex.js');
+const moveDataSource = load('script_res/move_data.js');
+load('script_res/ability_data.js');
+load('script_res/item_data.js');
+load('script_res/damage_MASTER.js');
+load('script_res/ko_chance.js');
+
+function protect(attacker, move) {
+    return context.setIsQuarteredByProtect(
+        { isDynamax: false, ...attacker },
+        {},
+        { isProtect: true },
+        { isZ: false, isSignatureZ: false, ...move },
+        {},
+    );
+}
+
+assert.equal(protect({ ability: 'Unseen Fist' }, { name: 'Close Combat', makesContact: true }), true);
+assert.equal(protect({ ability: 'Unseen Fist' }, { name: 'Dark Pulse', makesContact: false }), false);
+
+for (const attacker of [
+    { ability: 'Unseen Fist', item: 'Protective Pads' },
+    { ability: 'Unseen Fist', item: 'Punching Glove' },
+    { ability: 'Long Reach', item: '' },
+]) {
+    const move = { name: 'Drain Punch', makesContact: true, isPunch: true };
+    context.checkContactOverride(move, attacker);
+    assert.equal(move.makesContact, false);
+    assert.equal(protect(attacker, move), false);
+}
+
+assert.equal(protect({ ability: 'Piercing Drill' }, { name: 'Dark Pulse', makesContact: false }), true);
+assert.equal(protect({ ability: '' }, { name: 'Hydro Vortex', makesContact: false, isZ: true }), true);
+assert.equal(protect({ ability: '', isDynamax: true }, { name: 'Max Geyser', makesContact: false }), true);
+
+assert.ok(context.POKEDEX_CHAMPIONS.Grapploct);
+assert.equal(Object.values(context.POKEDEX_CHAMPIONS).includes(undefined), false);
+assert.deepEqual(
+    [context.POKEDEX_CHAMPIONS['Mega Chandelure'].t1, context.POKEDEX_CHAMPIONS['Mega Chandelure'].t2],
+    ['Ghost', 'Fire'],
+);
+
+assert.equal(context.MOVES_CHAMPIONS.Overdrive, context.MOVES_CHAMPIONS_NATDEX.Overdrive);
+assert.equal(context.MOVES_CHAMPIONS['Spit Up'], context.MOVES_CHAMPIONS_NATDEX['Spit Up']);
+assert.equal(context.MOVES_CHAMPIONS.Pound.bp, 40);
+assert.equal(context.MOVES_CHAMPIONS.Octazooka, undefined);
+assert.equal(context.MOVES_CHAMPIONS['Eerie Spell'].isSound, true);
+assert.equal(Object.keys(context.MOVES_CHAMPIONS).length, 513);
+assert.equal(context.ABILITIES_CHAMPIONS.length, new Set(context.ABILITIES_CHAMPIONS).size);
+assert.equal((moveDataSource.match(/'Snipe Shot': \{ bp: 85 \}/g) || []).length, 1);
+
+const spitUp = context.MOVES_CHAMPIONS['Spit Up'];
+assert.equal(spitUp.stockpileBP, true);
+assert.equal(spitUp.bp, 1);
+for (const [stockpiles, expectedBP] of [[0, 0], [1, 100], [2, 200], [3, 300]]) {
+    const move = { name: 'Spit Up', bp: spitUp.bp, stockpiles };
+    const [actualBP] = context.basePowerFunc(move, {}, '', {}, {}, {}, false, false, '');
+    assert.equal(actualBP, expectedBP);
+
+    const fixedDamage = context.setDamage(move, { ability: '' }, {}, {}, false, {});
+    if (stockpiles === 0) assert.equal(fixedDamage.damage[0], 0);
+    else assert.equal(fixedDamage, -1);
+}
+
+const eerieSpell = context.MOVES_CHAMPIONS['Eerie Spell'];
+const soundproofResult = context.immunityChecks(
+    eerieSpell,
+    {},
+    {},
+    {},
+    { attackerName: '', moveName: 'Eerie Spell', defenderName: '' },
+    'Soundproof',
+    1,
+);
+assert.deepEqual(Array.from(soundproofResult.damage), [0]);
+
+const [punkRockMods] = context.calcFinalMods(
+    eerieSpell,
+    { ability: '', item: '', hasCustomModifiers: false },
+    { isDynamax: false, curHP: 1, maxHP: 1, item: '' },
+    { format: 'Singles', isFriendGuard: false },
+    {},
+    false,
+    1,
+    'Punk Rock',
+);
+assert.deepEqual(Array.from(punkRockMods), [0x800]);
+
+function saltCure(types) {
+    const defender = {
+        maxHP: 160,
+        ability: '',
+        status: 'Healthy',
+        item: '',
+        hasType(...wanted) { return wanted.some(type => types.includes(type)); },
+    };
+    const field = {
+        isSaltCure: true,
+        weather: '',
+        terrain: '',
+        isGMaxField: false,
+        isAquaRing: false,
+        isIngrain: false,
+        isLeechSeed: false,
+        isNightmare: false,
+        isCurse: false,
+        isBinding: false,
+    };
+    return context.getAllEndOfTurnEffects(defender, field, false, false, false).saltCure.val;
+}
+
+assert.equal(saltCure(['Normal']), -10);
+assert.equal(saltCure(['Water']), -20);
+assert.equal(saltCure(['Steel']), -20);
+
+for (const filename of ['index.html', 'za-calc.html']) {
+    const html = fs.readFileSync(path.join(repo, filename), 'utf8');
+    assert.equal((html.match(/class="move-stockpiles calc-trigger hide"/g) || []).length, 8);
+}
+
+process.stdout.write('Champions PR acceptance checks passed.\n');

--- a/za-calc.html
+++ b/za-calc.html
@@ -238,6 +238,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL1" /><label class="double-btn btn x-btn" for="doubleL1" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL1" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL1" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -253,6 +254,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL2" /><label class="double-btn btn x-btn" for="doubleL2" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL2" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL2" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -268,6 +270,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL3" /><label class="double-btn btn x-btn" for="doubleL3" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL3" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL3" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -283,6 +286,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleL4" /><label class="double-btn btn x-btn" for="doubleL4" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarL4" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarL4" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -621,6 +625,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR1" /><label class="double-btn btn x-btn" for="doubleR1" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR1" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR1" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -636,6 +641,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR2" /><label class="double-btn btn x-btn" for="doubleR2" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR2" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR2" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -651,6 +657,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR3" /><label class="double-btn btn x-btn" for="doubleR3" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR3" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR3" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>
@@ -666,6 +673,7 @@
                         <input class="move-double calc-trigger btn-input hide" type="checkbox" id="doubleR4" /><label class="double-btn btn x-btn" for="doubleR4" title="Force this attack to deal double damage?">2x BP</label>
                         <select class="move-pledge calc-trigger hide"><option value="Grass Pledge">Grass Pledge</option><option value="Fire Pledge">Fire Pledge</option><option value="Water Pledge">Water Pledge</option></select>
                         <select class="move-linearAddedBP calc-trigger hide"><option value="0">0x effect</option><option value="1">1x effect</option><option value="2">2x effect</option><option value="3">3x effect</option><option value="4">4x effect</option><option value="5">5x effect</option><option value="6">6x effect</option></select>
+                        <select class="move-stockpiles calc-trigger hide"><option value="0">0 stockpiles</option><option value="1">1 stockpile</option><option value="2">2 stockpiles</option><option value="3">3 stockpiles</option></select>
                         <select class="move-opponent calc-trigger hide"><option value="1">Move 1</option><option value="2">Move 2</option><option value="3">Move 3</option><option value="4">Move 4</option></select>
                         <input class="move-stellar calc-trigger btn-input hide" type="checkbox" id="stellarR4" checked="checked" /><label class="stellar-btn btn xx-btn" for="stellarR4" title="Is this the first time using a move of this type after Terastalizing?">1st Use</label>
                     </div>


### PR DESCRIPTION
Fixes #62 and #63.

Two commits, each reviewable on its own.

## 1. Data divergences and Protect handling (#62)

- Require Champions Unseen Fist attacks to remain contact moves before they receive quarter damage through Protect.
- Synchronize the Champions roster and move metadata with the audited champout v1.2.0 data.
- Implement Spit Up's Stockpile-dependent damage with a dedicated 0-3 Stockpiles input.

The Protect fix is applied after the existing contact overrides, so Protective Pads, Punching Glove, and Long Reach correctly prevent Unseen Fist from using the through-Protect path. Existing Piercing Drill, Z-Move, and Max Move branches remain unchanged.

The data corrections:

- admit Grapploct under the correct spelling;
- admit Overdrive, Pound, and Spit Up, and remove unavailable Octazooka;
- set Champions Pound to 40 BP;
- mark Eerie Spell as a sound move;
- correct Mega Chandelure's type order to Ghost / Fire;
- remove duplicate Huge Power and Snipe Shot entries.

Spit Up keeps its internal variable-power representation and calculates 0/100/200/300 BP at 0/1/2/3 Stockpiles. At zero Stockpiles it returns zero damage. Z-Move and Max Move handling therefore continue to use the existing variable-power special cases.

## 2. Five damage-formula bugs (#63)

All in `script_res/damage_MASTER.js`:

- **Gyro Ball** base power is `25 × target Speed ÷ user Speed + 1`; the `+ 1` was missing, so every Gyro Ball was one point weak.
- **Plus / Minus** applied their 1.5x to physical moves. They raise Sp. Atk only, so the branch now checks the move category.
- **Pain Split** returned `floor((targetHP - userHP) / 2)`, which goes negative when the user has more HP and is one low whenever the HP total is odd. It now computes the target's drop to the average HP and clamps at zero.
- **Terrain Pulse** took its type from the terrain regardless of grounding, while the doubled base power in `basePowerFunc` was already gated on `attIsGrounded`. The type now uses the same gate.
- **Steel Roller** dealt full damage with no terrain active; it now deals none.

## Verification

- `node tests/champions_pr_acceptance.js` covers every item in both commits.
- `node --check` on every modified JavaScript source and the test.
- Compared the resulting runtime data against `projectpokemon/champout@50e7233b78c3b81df29563f9695386c28e77fc95`:
  - 346/346 admitted Pokemon are defined
  - 512 real Champions moves exactly match the 512 `available=1` champout moves
  - 216 abilities are unique
  - 166 items match exactly
- Re-ran the focused rule audit: 34/34 data-field checks and 5/5 mechanics checks pass.
- Salt Cure remains unchanged at 160 HP: 10 damage to ordinary types and 20 damage to Water or Steel types.
- Ran 1200 randomised Champions calcs (random species, move, ability, item, nature, stat stages, status, weather, terrain, singles and doubles) against an independent engine before and after. The five formula fixes account for every disagreement they were expected to; the remainder are known modelling differences on the other engine's side.
